### PR TITLE
Reject random

### DIFF
--- a/gunpowder/nodes/reject.py
+++ b/gunpowder/nodes/reject.py
@@ -45,7 +45,7 @@ class Reject(BatchFilter):
 
             batch = self.upstream_provider.request_batch(request)
             mask_ratio = batch.arrays[self.mask].data.mean()
-            have_good_batch = mask_ratio>=self.min_masked
+            have_good_batch = mask_ratio>self.min_masked
 
             if not have_good_batch and self.reject_probability < 1.:
                 have_good_batch = random.random() > self.reject_probability

--- a/gunpowder/nodes/reject.py
+++ b/gunpowder/nodes/reject.py
@@ -1,4 +1,5 @@
 import logging
+import random
 
 from .batch_filter import BatchFilter
 from gunpowder.profiling import Timing
@@ -14,11 +15,16 @@ class Reject(BatchFilter):
 
         min_masked(float, optional): The minimal required ratio of masked-in
             vs. masked-out voxels. Defaults to 0.5.
+
+        reject_probability(float, optional): The probability by which a batch
+            that is not valid (less than min_masked) is actually rejected.
+            Defaults to 1., i.e. strict rejection.
     '''
 
-    def __init__(self, mask, min_masked=0.5):
+    def __init__(self, mask, min_masked=0.5, reject_probability=1.):
         self.mask = mask
         self.min_masked = min_masked
+        self.reject_probability = reject_probability
 
     def setup(self):
         assert self.mask in self.spec, "Reject can only be used if %s is provided"%self.mask
@@ -40,6 +46,12 @@ class Reject(BatchFilter):
             batch = self.upstream_provider.request_batch(request)
             mask_ratio = batch.arrays[self.mask].data.mean()
             have_good_batch = mask_ratio>=self.min_masked
+
+            if not have_good_batch and self.reject_probability < 1.:
+                have_good_batch = random.random() > self.reject_probability
+                logger.debug(
+                    "accepted batch with mask ratio %f at" %mask_ratio +
+                    str(batch.arrays[self.mask].spec.roi))
 
             if not have_good_batch:
 


### PR DESCRIPTION
Adding new functionality to the Reject node:
If a batch does not fulfill the criterion at hand (i.e. `mask_ratio > min_masked`), it is still only rejected with a given probability.
Additionally, the rejection criterion is changed from `>= min_masked` to `> min_masked` to make  `min_masked = 0` work as intended. 