### PR TITLE
Improve testing infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
 default:
 	python setup.py install
 	-rm -rf dist build gunpowder.egg-info
+
+.PHONY: dev
+dev:
+	pip install -e .
+
+.PHONY: test
+test:
+	python tests/test_suite.py

--- a/gunpowder/caffe/nodes/predict.py
+++ b/gunpowder/caffe/nodes/predict.py
@@ -57,7 +57,7 @@ class Predict(GenericPredict):
         self.weights = weights
         self.inputs = inputs
         self.outputs = outputs
-	self.use_gpu = use_gpu
+        self.use_gpu = use_gpu
 
     def start(self):
 

--- a/tests/cases/dvid_source.py
+++ b/tests/cases/dvid_source.py
@@ -40,7 +40,7 @@ class TestDvidSource(ProviderTest):
                     seg: '/volumes/labels/neuron_ids',
                     mask: '/volumes/labels/mask'
                 },
-                output_filename = 'dvid_source_test.hdf'
+                output_filename = self.path_to('dvid_source_test.hdf')
             )
         )
 

--- a/tests/cases/hdf5_source.py
+++ b/tests/cases/hdf5_source.py
@@ -6,9 +6,10 @@ from gunpowder.ext import h5py
 class TestHdf5Source(ProviderTest):
 
     def test_output_2d(self):
+        path = self.path_to('test_hdf_source.hdf')
 
         # create a test file
-        with h5py.File('test_hdf_source.hdf', 'w') as f:
+        with h5py.File(path, 'w') as f:
             f['raw'] = np.zeros((100, 100), dtype=np.float32)
             f['raw_low'] = np.zeros((10, 10), dtype=np.float32)
             f['raw_low'].attrs['resolution'] = (10, 10)
@@ -19,7 +20,7 @@ class TestHdf5Source(ProviderTest):
         raw_low = ArrayKey('RAW_LOW')
         seg = ArrayKey('SEG')
         source = Hdf5Source(
-            'test_hdf_source.hdf',
+            path,
             {
                 raw: 'raw',
                 raw_low: 'raw_low',
@@ -42,9 +43,10 @@ class TestHdf5Source(ProviderTest):
             self.assertFalse(batch.arrays[seg].spec.interpolatable)
 
     def test_output_3d(self):
+        path = self.path_to('test_hdf_source.hdf')
 
         # create a test file
-        with h5py.File('test_hdf_source.hdf', 'w') as f:
+        with h5py.File(path, 'w') as f:
             f['raw'] = np.zeros((100, 100, 100), dtype=np.float32)
             f['raw_low'] = np.zeros((10, 10, 10), dtype=np.float32)
             f['raw_low'].attrs['resolution'] = (10, 10, 10)
@@ -55,7 +57,7 @@ class TestHdf5Source(ProviderTest):
         raw_low = ArrayKey('RAW_LOW')
         seg = ArrayKey('SEG')
         source = Hdf5Source(
-            'test_hdf_source.hdf',
+            path,
             {
                 raw: 'raw',
                 raw_low: 'raw_low',

--- a/tests/cases/hdf5_write.py
+++ b/tests/cases/hdf5_write.py
@@ -50,6 +50,7 @@ class Hdf5WriteTestSource(BatchProvider):
 class TestHdf5Write(ProviderTest):
 
     def test_output(self):
+        path = self.path_to('hdf5_write_test.hdf')
 
         source = Hdf5WriteTestSource()
 
@@ -62,7 +63,7 @@ class TestHdf5Write(ProviderTest):
             Hdf5Write({
                 ArrayKeys.RAW: 'arrays/raw'
             },
-            output_filename='hdf5_write_test.hdf') +
+            output_filename=path) +
             Scan(chunk_request))
 
         with build(pipeline):
@@ -80,7 +81,7 @@ class TestHdf5Write(ProviderTest):
 
         # assert that stored HDF dataset equals batch array
 
-        with h5py.File('hdf5_write_test.hdf', 'r') as f:
+        with h5py.File(path, 'r') as f:
 
             ds = f['arrays/raw']
 

--- a/tests/cases/provider_test.py
+++ b/tests/cases/provider_test.py
@@ -1,6 +1,12 @@
+
 from gunpowder import *
+import shutil
+import os
 import copy
+from warnings import warn
 import unittest
+from datetime import datetime
+from tempfile import mkdtemp
 import numpy as np
 
 class TestSource(BatchProvider):
@@ -28,10 +34,80 @@ class TestSource(BatchProvider):
         return batch
 
 
-class ProviderTest(unittest.TestCase):
+class TestWithTempFiles(unittest.TestCase):
+    """
+    Usage:
+
+    If your test case dumps out any files, use ``self.path_to("path", "to", "my.file")`` to get the path to a directory
+    in your temporary directory. This will be namespaced by the test class, timestamp and test method, e.g.
+
+    >>> self.path_to("path", "to", "my.file")
+    /tmp/gunpowder_MyTestCase_2018-03-08T18:32:18.967927_r4nd0m/my_test_method/path/to/my.file
+
+    Each test method's data will be deleted after the test case is run (regardless of pass, fail or error).
+    To disable test method data deletion, set ``self._cleanup = False`` anywhere in the test.
+
+    The test case directory will be deleted after every test method is run, unless there is data left in it.
+    Any files written directly to the class output directory (rather than the test output subdirectory) should therefore
+    be explicitly removed before tearDownClass is called.
+    To disable data deletion for the whole class (the test case directory and all tests), set ``_cleanup = False`` in the
+    class definition. N.B. doing this in a method (``type(self)._cleanup = False``) will have unexpected results
+    depending on the order of test execution.
+
+    Subclasses implementing their own setUp, setUpClass, tearDown and tearDownClass should explicitly call the
+    ``super`` method in the method definition.
+    """
+    _output_root = ''
+    _cleanup = True
+
+    def path_to(self, *args):
+        return type(self).path_to_cls(self._testMethodName, *args)
+
+    @classmethod
+    def path_to_cls(cls, *args):
+        return os.path.join(cls._output_root, *args)
+
+    @classmethod
+    def setUpClass(cls):
+        timestamp = datetime.now().isoformat()
+        cls._output_root = mkdtemp(prefix='gunpowder_{}_{}_'.format(cls.__name__, timestamp))
 
     def setUp(self):
+        os.mkdir(self.path_to())
 
+    def tearDown(self):
+        path = self.path_to()
+        try:
+            if self._cleanup:
+                shutil.rmtree(path)
+            else:
+                warn('Directory {} was not deleted'.format(path))
+        except OSError as e:
+            if '[Errno 2]' in str(e):
+                pass
+            else:
+                raise
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if cls._cleanup:
+                os.rmdir(cls.path_to_cls())
+            else:
+                warn('Directory {} was not deleted'.format(cls.path_to_cls()))
+        except OSError as e:
+            if '[Errno 39]' in str(e):
+                warn('Directory {} could not be deleted as it still had data in it'.format(cls.path_to_cls()))
+            elif '[Errno 2]' in str(e):
+                pass
+            else:
+                raise
+
+
+class ProviderTest(TestWithTempFiles):
+
+    def setUp(self):
+        super(ProviderTest, self).setUp()
         # create some common array keys to be used by concrete tests
         ArrayKey('RAW')
         ArrayKey('GT_LABELS')


### PR DESCRIPTION
Resolves #26

ProviderTest now inherits from TestWithTempFiles, which creates and then destroys timestamped directories in the user's temp directory for storing test-related output files. The path to these files can be accessed with `self.path_to('my.file')` and file cleanup can be disabled for any given test by setting `self._cleanup = False` anywhere in the body of the test.

Any subclasses overriding `setUp`, `setUpClass`, `tearDown`, or `tearDownClass` should also call the super method.

Also `make dev` and `make test` recipes for editable installs and running unit tests.