### PR TITLE
Tox and extras config (for py3 testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
 language: python
 python:
   - "2.7"
+#  - "3.4"
+#  - "3.5"
+#  - "3.6"
 install:
   - sudo apt-get update
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
-  - source activate test-environment
-  - conda install tensorflow
-  - python setup.py install
-
+  - pip install -U pip
+  - pip install tox-travis
 script:
-  - python tests/test_suite.py
+  - tox

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 default:
-	python setup.py install
+	pip install .
 	-rm -rf dist build gunpowder.egg-info
 
-.PHONY: dev
-dev:
-	pip install -e .
+.PHONY: install-full
+install-full:
+	pip install .[full]
+
+.PHONY: install-dev
+install-dev:
+	pip install -e .[full]
 
 .PHONY: test
 test:
 	python tests/test_suite.py
+
+.PHONY: test-all
+test-all:
+	tox

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,26 @@
 from setuptools import setup
+import subprocess
+try:
+    import base_string as string_types
+except ImportError:
+    string_types = str
+
+extras_require = {
+    'tensorflow': ['tensorflow'],
+    'test': ['tox']
+}
+
+
+dep_set = set()
+for value in extras_require.values():
+    if isinstance(value, string_types):
+        dep_set.add(value)
+    else:
+        dep_set.update(value)
+
+extras_require['full'] = list(dep_set)
+
+subprocess.call('pip install git+https://github.com/funkey/augment#egg=augment'.split())
 
 setup(
         name='gunpowder',
@@ -24,8 +46,7 @@ setup(
             "scipy",
             "h5py",
             "scikit-image",
-            "augment",
             "requests"
         ],
-        dependency_links=['git+https://github.com/funkey/augment#egg=augment']
+        extras_require=extras_require,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27
+#envlist = py27, py34, py35, py36
+
+[testenv]
+whitelist_externals =
+    make
+commands =
+    make install-full
+    make test


### PR DESCRIPTION
This PR doesn't really add any value, but it will make it much easier to test against multiple versions of python in the (near) future.

However, it includes a slightly dirty hack to `setup.py` to allow gunpowder to be installed using `pip` (which makes it much easier for downstream packages and is necessary for a clean [editable](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs) install, as `setup.py develop` is not recommended, I think). The reasons for this are documented here: https://github.com/funkey/augment/issues/1

Up to you if you want to go down this route; otherwise I'll use this branch for my own testing and then try to strip it out before making a PR for py3.