### PR TITLE
add node for noise augmentation

### DIFF
--- a/gunpowder/nodes/__init__.py
+++ b/gunpowder/nodes/__init__.py
@@ -20,6 +20,7 @@ from .klb_source import KlbSource
 from .merge_provider import MergeProvider
 from .n5_source import N5Source
 from .n5_write import N5Write
+from .noise_augment import NoiseAugment
 from .normalize import Normalize
 from .pad import Pad
 from .precache import PreCache

--- a/gunpowder/nodes/noise_augment.py
+++ b/gunpowder/nodes/noise_augment.py
@@ -1,0 +1,43 @@
+import numpy as np
+import skimage
+
+from .batch_filter import BatchFilter
+
+class NoiseAugment(BatchFilter):
+    '''Add random noise to an array. Uses the scikit-image function skimage.util.random_noise.
+    See scikit-image documentation for more information on arguments and additional kwargs.
+
+    Args:
+
+        array (:class:`ArrayKey`):
+
+            The intensity array to modify. Should be of type float and within range [-1, 1] or [0, 1].
+
+        mode (``string``):
+
+            Type of noise to add, see scikit-image documentation.
+
+        seed (``int``):
+
+            Optionally set a random seed, see scikit-image documentation.
+
+        clip (``bool``):
+
+            Whether to preserve the image range (either [-1, 1] or [0, 1]) by clipping values in the end, see
+            scikit-image documentation
+    '''
+
+    def __init__(self, array, mode='gaussian', seed=None, clip=True, **kwargs):
+        self.array = array
+        self.mode = mode
+        self.seed = seed
+        self.clip = clip
+        self.kwargs = kwargs
+
+    def process(self, batch, request):
+
+        raw = batch.arrays[self.array]
+
+        assert raw.data.dtype == np.float32 or raw.data.dtype == np.float64, "Noise augmentation requires float types for the raw array (not " + str(raw.data.dtype) + "). Consider using Normalize before."
+        assert raw.data.min() >= -1 and raw.data.max() <= 1, "Noise augmentation expects raw values in [-1,1] or [0,1]. Consider using Normalize before."
+        raw.data = skimage.util.random_noise(raw.data, mode=self.mode, seed=self.seed, clip=self.clip, **self.kwargs )


### PR DESCRIPTION
This node can be used to add noise of various types to a float-type array.  It is essentially a wrapper around `scikit-image`'s `skimage.util.random_noise()`.