### PR TITLE
Add option to store min/max of datasets in snapshots

### DIFF
--- a/gunpowder/nodes/snapshot.py
+++ b/gunpowder/nodes/snapshot.py
@@ -128,8 +128,9 @@ class Snapshot(BatchFilter):
                     dataset.attrs['resolution'] = self.spec[array_key].voxel_size
 
                     if self.store_value_range:
-                        dataset.attrs['valueRangeMin'] = np.asscalar(array.data.min())
-                        dataset.attrs['valueRangeMax'] = np.asscalar(array.data.max())
+                        dataset.attrs['value_range'] = (
+                            np.asscalar(array.data.min()),
+                            np.asscalar(array.data.max()))
 
                     # if array has attributes, add them to the dataset
                     for attribute_name, attribute in array.attrs.items():

--- a/gunpowder/nodes/snapshot.py
+++ b/gunpowder/nodes/snapshot.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 import os
 
 from .batch_filter import BatchFilter
@@ -53,6 +54,10 @@ class Snapshot(BatchFilter):
             A dictionary from array keys to datatype (eg. ``np.int8``). If
             given, arrays are stored using this type. The original arrays
             within the pipeline remain unchanged.
+
+        store_value_range (``bool``):
+
+            If set to ``True`, store range of values in data set attributes.
         '''
 
     def __init__(
@@ -63,7 +68,8 @@ class Snapshot(BatchFilter):
             every=1,
             additional_request=None,
             compression_type=None,
-            dataset_dtypes=None):
+            dataset_dtypes=None,
+            store_value_range=False):
         self.dataset_names = dataset_names
         self.output_dir = output_dir
         self.output_filename = output_filename
@@ -71,6 +77,7 @@ class Snapshot(BatchFilter):
         self.additional_request = BatchRequest() if additional_request is None else additional_request
         self.n = 0
         self.compression_type = compression_type
+        self.store_value_range = store_value_range
         if dataset_dtypes is None:
             self.dataset_dtypes = {}
         else:
@@ -119,6 +126,10 @@ class Snapshot(BatchFilter):
                     
                     dataset.attrs['offset'] = offset
                     dataset.attrs['resolution'] = self.spec[array_key].voxel_size
+
+                    if self.store_value_range:
+                        dataset.attrs['valueRangeMin'] = np.asscalar(array.data.min())
+                        dataset.attrs['valueRangeMax'] = np.asscalar(array.data.max())
 
                     # if array has attributes, add them to the dataset
                     for attribute_name, attribute in array.attrs.items():


### PR DESCRIPTION
This is useful when displaying a snapshot to infer an appropriate contrast range automatically.

I tried to store a dictionary {'valueRange': {'min': <min>, 'max': <max>}} but that does not seem to work with hdf5
If there is a way to actually do that in hdf5, please let me know.
Note: dumping as json string stores a string (and not a json/dictionary object)