### PR TITLE
Support multiclass label balancing

### DIFF
--- a/gunpowder/nodes/balance_labels.py
+++ b/gunpowder/nodes/balance_labels.py
@@ -9,14 +9,16 @@ logger = logging.getLogger(__name__)
 
 
 class BalanceLabels(BatchFilter):
-    '''Creates a scale array to balance the loss between positive and negative
-    labels.
+    '''Creates a scale array to balance the loss between class labels.
+
+    Note that this only balances loss weights per-batch and does not accumulate
+    statistics about class balance across batches.
 
     Args:
 
         labels (:class:`ArrayKey`):
 
-            A array containing binary labels.
+            An array containing binary or integer labels.
 
         scales (:class:`ArrayKey`):
 
@@ -39,9 +41,15 @@ class BalanceLabels(BatchFilter):
 
             will perform the balancing for every each slice ``[0:2,:]``,
             ``[2:4,:]``, ... individually.
+
+        num_classes(``int``, optional):
+
+            The number of classes. Labels will be expected to be in the
+            interval [0, ``num_classes``). Defaults to 2 for binary
+            classification.
     '''
 
-    def __init__(self, labels, scales, mask=None, slab=None):
+    def __init__(self, labels, scales, mask=None, slab=None, num_classes=2):
 
         self.labels = labels
         self.scales = scales
@@ -53,6 +61,7 @@ class BalanceLabels(BatchFilter):
             self.masks = mask
 
         self.slab = slab
+        self.num_classes = num_classes
 
     def setup(self):
 
@@ -73,12 +82,12 @@ class BalanceLabels(BatchFilter):
 
         labels = batch.arrays[self.labels]
 
-        assert len(np.unique(labels.data)) <= 2, (
-            "Found more than two labels in %s."%self.labels)
-        assert np.min(labels.data) in [0.0, 1.0], (
-            "Labels %s are not binary."%self.labels)
-        assert np.max(labels.data) in [0.0, 1.0], (
-            "Labels %s are not binary."%self.labels)
+        assert len(np.unique(labels.data)) <= self.num_classes, (
+            "Found more unique labels than classes in %s."%self.labels)
+        assert 0 <= np.min(labels.data) < self.num_classes, (
+            "Labels %s are not in [0, num_classes)."%self.labels)
+        assert 0 <= np.max(labels.data) < self.num_classes, (
+            "Labels %s are not in [0, num_classes)."%self.labels)
 
         # initialize error scale with 1s
         error_scale = np.ones(labels.data.shape, dtype=np.float32)
@@ -120,16 +129,16 @@ class BalanceLabels(BatchFilter):
 
     def __balance(self, labels, scale):
 
-        # in the masked-in area, compute the fraction of positive samples
+        # in the masked-in area, compute the fraction of per-class samples
         masked_in = scale.sum()
-        num_pos  = (labels*scale).sum()
-        frac_pos = float(num_pos) / masked_in if masked_in > 0 else 0
-        frac_pos = np.clip(frac_pos, 0.05, 0.95)
-        frac_neg = 1.0 - frac_pos
+        classes, counts = np.unique(labels[np.nonzero(scale)], return_counts=True)
+        fracs = counts.astype(float) / masked_in if masked_in > 0 else np.zeros(counts.size)
+        np.clip(fracs, 0.05, 0.95, fracs)
 
-        # compute the class weights for positive and negative samples
-        w_pos = 1.0 / (2.0 * frac_pos)
-        w_neg = 1.0 / (2.0 * frac_neg)
+        # compute the class weights
+        w_sparse = 1.0 / float(self.num_classes) / fracs
+        w = np.zeros(self.num_classes)
+        w[classes] = w_sparse
 
         # scale the masked-in scale with the class weights
-        scale *= (labels >= 0.5) * w_pos + (labels < 0.5) * w_neg
+        scale *= np.take(w, labels)


### PR DESCRIPTION
This may require some feedback/changes before merge, since there's reference to non-integral label support in df6186c1c5601df676e5937fd6e71abd77deb2d7. It's not clear whether `BalanceLabels` is intended to work with either or both of labels and soft targets. The scaling of the weight vector by the number of classes is also somewhat arbitrary, but is consistent with the existing binary behavior.