### PR TITLE
Increment Snapshot.n only once per request

### DIFF
--- a/gunpowder/nodes/snapshot.py
+++ b/gunpowder/nodes/snapshot.py
@@ -79,7 +79,6 @@ class Snapshot(BatchFilter):
     def prepare(self, request):
 
         self.record_snapshot = self.n%self.every == 0
-        self.n += 1
 
         # append additional array requests, don't overwrite existing ones
         for array_key, spec in self.additional_request.array_specs.items():


### PR DESCRIPTION
Currently, happens both in [`Snapshot.prepare`](https://github.com/hanslovsky/gunpowder/blob/44590cb7d01406954cf8a50de394656223be5ed3/gunpowder/nodes/snapshot.py#L82) as well as in [`Snapshot.process`](https://github.com/hanslovsky/gunpowder/blob/44590cb7d01406954cf8a50de394656223be5ed3/gunpowder/nodes/snapshot.py#L130).