### PR TITLE
Add augment to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
             "scipy",
             "h5py",
             "scikit-image",
-            "requests"
+            "requests",
+            "augment @ git+https://github.com/funkey/augment"
         ],
         extras_require=extras_require,
 )


### PR DESCRIPTION
Fixes #38 

This works for me with pip version:
```bash
$ pip --version
pip 18.1 from /usr/lib/python3.7/site-packages/pip (python 3.7)
$pip2 --version
pip 18.1 from /usr/lib/python2.7/site-packages/pip (python 2.7)
```

Before a merge:
 - This should be tested with older versions of pip if there is a desire to support older versions
 - Consider specifying a commit or tag/release (preferred) for augment dependency