### PR TITLE
Fix bug in gunpowder train node

### DIFF
--- a/gunpowder/tensorflow/nodes/train.py
+++ b/gunpowder/tensorflow/nodes/train.py
@@ -146,9 +146,7 @@ class Train(GenericTrain):
         # at least for some versions of tensorflow, the checkpoint name has to
         # start with a . if it is a relative path
         if not os.path.isabs(self.meta_graph_filename):
-            self.meta_graph_filename = os.path.join(
-                '.'.
-                self.meta_graph_filename)
+            self.meta_graph_filename = os.path.join('.', self.meta_graph_filename)
 
     def start(self):
 


### PR DESCRIPTION
Replace `'.'.` with `'.',`

Bug was introduced in a46e3635021938156476273ff363b04ad289625b