### PR TITLE
Add version_info

### DIFF
--- a/gunpowder/__init__.py
+++ b/gunpowder/__init__.py
@@ -15,6 +15,7 @@ from .provider_spec import ProviderSpec
 from .roi import Roi
 from .array import Array, ArrayKey, ArrayKeys
 from .array_spec import ArraySpec
+from .version_info import _version as version
 import gunpowder.caffe
 import gunpowder.tensorflow
 import gunpowder.contrib

--- a/gunpowder/version_info.py
+++ b/gunpowder/version_info.py
@@ -1,0 +1,30 @@
+__major__   = 1
+__minor__   = 0
+__patch__   = 0
+__tag__     = 'rc0.dev0'
+__version__ = '{}.{}.{}{}'.format(__major__, __minor__, __patch__, __tag__).strip('.')
+
+class _Version(object):
+
+    def major(self):
+        return __major__
+
+    def minor(self):
+        return __minor__
+
+    def patch(self):
+        return __patch__
+
+    def tag(self):
+        return __tag__
+
+    def version(self):
+        return __version__
+
+    def __str__(self):
+        return self.version()
+
+_version = _Version()
+
+if __name__ == "__main__":
+    print(_version)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from setuptools import setup
 try:
     import base_string as string_types
@@ -18,9 +19,17 @@ for value in extras_require.values():
 
 extras_require['full'] = list(dep_set)
 
+name = 'gunpowder'
+here = os.path.abspath(os.path.dirname(__file__))
+version_info = {}
+with open(os.path.join(here, name, 'version_info.py')) as fp:
+    exec(fp.read(), version_info)
+version = version_info['_version']
+
+
 setup(
-        name='gunpowder',
-        version='0.3.2',
+        name=name,
+        version=str(version),
         description='Data loading DAG for Greentea.',
         url='https://github.com/funkey/gunpowder',
         author='Jan Funke',


### PR DESCRIPTION
I added a `version_info` module to
 - follow [SemVer](https://semver.org/)
 - encourage frequent deployment of development versions to pypi via
   - patch versions
   - the `devN` tag
 - make version easily accessible from within python code

For downstream packages it would be super useful to have more frequent (development) releases on PyPI. For development releases this could happen nightly (or arbitrarily) via bumping the `devN` tag.