### PR TITLE
enable channels_last for hdf5like source

### DIFF
--- a/gunpowder/nodes/hdf5_source.py
+++ b/gunpowder/nodes/hdf5_source.py
@@ -26,6 +26,14 @@ class Hdf5Source(Hdf5LikeSource):
             the array specs automatically determined from the data file. This
             is useful to set a missing ``voxel_size``, for example. Only fields
             that are not ``None`` in the given :class:`ArraySpec` will be used.
+
+        channels_first (``bool``, optional):
+
+            Specifies the ordering of the dimensions of the HDF5-like data source.
+            If channels_first is set (default), then the input shape is expected
+            to be (channels, spatial dimensions). This is recommended because of
+            better performance. If channels_first is set to false, then the input
+            data is read in channels_last manner and converted to channels_first.
     '''
     def _open_file(self, filename):
         return h5py.File(filename, 'r')

--- a/gunpowder/nodes/hdf5like_source_base.py
+++ b/gunpowder/nodes/hdf5like_source_base.py
@@ -192,8 +192,8 @@ class Hdf5LikeSource(BatchProvider):
             array = np.asarray(data_file[ds_name][(slice(None),) * c + roi.to_slices()])
         else:
             array = np.asarray(data_file[ds_name][roi.to_slices() + (slice(None),) * c])
-            array = np.transpose(array, 
-                    axes=[i + self.ndims for i in range(c)] + list(range(self.ndims)))
+            array = np.transpose(array,
+                                 axes=[i + self.ndims for i in range(c)] + list(range(self.ndims)))
 
         return array
 

--- a/gunpowder/nodes/n5_source.py
+++ b/gunpowder/nodes/n5_source.py
@@ -33,6 +33,14 @@ class N5Source(Hdf5LikeSource):
             the array specs automatically determined from the data file. This
             is useful to set a missing ``voxel_size``, for example. Only fields
             that are not ``None`` in the given :class:`ArraySpec` will be used.
+
+        channels_first (``bool``, optional):
+
+            Specifies the ordering of the dimensions of the HDF5-like data source.
+            If channels_first is set (default), then the input shape is expected
+            to be (channels, spatial dimensions). This is recommended because of
+            better performance. If channels_first is set to false, then the input
+            data is read in channels_last manner and converted to channels_first.
     '''
     def _get_voxel_size(self, dataset):
         try:

--- a/gunpowder/nodes/zarr_source.py
+++ b/gunpowder/nodes/zarr_source.py
@@ -28,6 +28,14 @@ class ZarrSource(Hdf5LikeSource):
             the array specs automatically determined from the data file. This
             is useful to set a missing ``voxel_size``, for example. Only fields
             that are not ``None`` in the given :class:`ArraySpec` will be used.
+
+        channels_first (``bool``, optional):
+
+            Specifies the ordering of the dimensions of the HDF5-like data source.
+            If channels_first is set (default), then the input shape is expected
+            to be (channels, spatial dimensions). This is recommended because of
+            better performance. If channels_first is set to false, then the input
+            data is read in channels_last manner and converted to channels_first.
     '''
 
     def _get_voxel_size(self, dataset):


### PR DESCRIPTION
Add optional argument channels_first to Hdf5LikeSource with default value true.
If channels_first is set to false, then the data source is read in channels_last manner.