### PR TITLE
fix uint16 normalization

### DIFF
--- a/gunpowder/nodes/normalize.py
+++ b/gunpowder/nodes/normalize.py
@@ -48,7 +48,7 @@ class Normalize(BatchFilter):
             if array.data.dtype == np.uint8:
                 factor = 1.0/255
             elif array.data.dtype == np.uint16:
-                factor = 1.0/(255*255)
+                factor = 1.0/(256*256-1)
             elif array.data.dtype == np.float32:
                 assert array.data.min() >= 0 and array.data.max() <= 1, (
                         "Values are float but not in [0,1], I don't know how "


### PR DESCRIPTION
or maybe:

            if array.data.dtype == np.uint8:
                factor = 1.0/np.iinfo(np.uint8).max
            elif array.data.dtype == np.uint16:
                factor = 1.0/np.iinfo(np.uint16).max