### PR TITLE
Fix bug: Duplicating counts in ProfilingStats

### DIFF
--- a/gunpowder/batch.py
+++ b/gunpowder/batch.py
@@ -171,7 +171,7 @@ class Batch(Freezable):
 
         return cropped
 
-    def merge(self, batch):
+    def merge(self, batch, merge_profiling_stats=True):
         '''Merge this batch (``a``) with another batch (``b``).
 
         This creates a new batch ``c`` containing arrays and point sets from
@@ -195,7 +195,8 @@ class Batch(Freezable):
             else:
                 merged[key] = merged[key].merge(val)
 
-        merged.profiling_stats.merge_with(batch.profiling_stats)
+        if merge_profiling_stats:
+            merged.profiling_stats.merge_with(batch.profiling_stats)
         if batch.loss is not None:
             merged.loss = batch.loss
         if batch.iteration is not None:

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -139,7 +139,7 @@ class BatchFilter(BatchProvider):
             else:
                 node_batch = batch
             self.process(node_batch, downstream_request)
-            batch = batch.merge(node_batch).crop(downstream_request)
+            batch = batch.merge(node_batch, merge_profiling_stats=False).crop(downstream_request)
 
         timing_process.stop()
 


### PR DESCRIPTION
- fixed duplicating counts in profiling_stats
- fixed bug in merge points where deleted points would be replaced in merge

batch_filter doubles all TimingSummary counts in its batch.
This occurs because the batch.crop simply copies profiling_stats.
Merging batch and node_batch ends up merging the profiling_stats with itself.

My quick hacky solution:
Simply add a flag for if we want to merge profiling stats.

A potentially better solution:
Require process to create and return a batch. This way the `node_batch` would
not contain any upstream `profiling_stats`, and would only add its own timings
to the batch. 
This would require modifying every subclass of `BatchFilter` but would be more
fitting with the design of node_dependencies.