### PR TITLE
Rewrite specified location node to include jitter, boundary check

### DIFF
--- a/gunpowder/nodes/specified_location.py
+++ b/gunpowder/nodes/specified_location.py
@@ -140,7 +140,7 @@ class SpecifiedLocation(BatchFilter):
             for point_id, point in batch.points[points_key].data.items():
                 batch.points[points_key].data[point_id].location -= self.specified_shift
 
-    def _get_next_shift(self, center_shift):
+    def _get_next_shift(self, center_shift, shift_roi):
         # gets next coordinate from list
 
         if self.choose_randomly:
@@ -150,6 +150,10 @@ class SpecifiedLocation(BatchFilter):
             if self.loc_i >= len(self.coordinates):
                 self.loc_i = 0
                 logger.warning('Ran out of specified locations, looping list')
-
-        next_shift = Coordinate(self.coordinates[self.loc_i] - center_shift)
+        if shift_roi.contains(self.coordinates[self.loc_i]):
+            next_shift = Coordinate(self.coordinates[self.loc_i] - center_shift)
+        else:
+            logger.warn("Skipping point %s, outside of shift roi %s" %
+                        (self.coordinates[self.loc_i], shift_roi))
+            next_shift = self._get_next_shift(center_shift, shift_roi)
         return next_shift

--- a/gunpowder/nodes/specified_location.py
+++ b/gunpowder/nodes/specified_location.py
@@ -144,7 +144,7 @@ class SpecifiedLocation(BatchFilter):
                     "Requested %s, but upstream does not provide it."%key)
             shifted_roi = request_roi.shift(self.specified_shift)
             if not provided_roi.contains(shifted_roi):
-                logger.debug("Provided roi %s for key %s does not contain shifted roi %s"
+                logger.warning("Provided roi %s for key %s does not contain shifted roi %s"
                              % (provided_roi, key, shifted_roi))
                 return False
         return True

--- a/gunpowder/nodes/specified_location.py
+++ b/gunpowder/nodes/specified_location.py
@@ -1,4 +1,4 @@
-from random import choice
+from random import randrange
 import logging
 import numpy as np
 
@@ -35,12 +35,21 @@ class SpecifiedLocation(BatchFilter):
             A list of data that will be passed along with the arrays provided
             by this node. This data will be appended as an attribute to the
             dataset so it must be a data format compatible with hdf5.
+
+        jitter (``tuple`` of int):
+
+            How far to allow the point to shift in each direction.
+            Default is None, which places the point in the center.
+            Chooses uniformly from [loc - jitter, loc + jitter] in each
+            direction.
     '''
 
-    def __init__(self, locations, choose_randomly=False, extra_data=None):
+    def __init__(self, locations, choose_randomly=False, extra_data=None,
+                 jitter=None):
 
         self.coordinates = locations
         self.choose_randomly = choose_randomly
+        self.jitter = jitter
         self.loc_i = 0
         self.upstream_spec = None
         self.upstream_roi = None
@@ -79,8 +88,10 @@ class SpecifiedLocation(BatchFilter):
             else:
                 raise Exception(
                     "Requested %s, but upstream does not provide it."%key)
-            key_shift_roi = provided_roi.shift(-request_roi.get_begin()).grow((0, 0, 0),
-                                                    -request_roi.get_shape())
+            key_shift_roi = provided_roi.shift(
+                -request_roi.get_begin()).grow(
+                    Coordinate((0,)*request_roi.dims()),
+                    -request_roi.get_shape())
 
             if shift_roi is None:
                 shift_roi = key_shift_roi
@@ -93,14 +104,25 @@ class SpecifiedLocation(BatchFilter):
         center_shift = spec.roi.get_shape()/2 + spec.roi.get_offset()
 
         self.specified_shift = self._get_next_shift(center_shift)
+        if self.jitter is not None:
+            rnd = []
+            for i in range(len(self.jitter)):
+                rnd.append(np.random.randint(-self.jitter[i],
+                                              self.jitter[i]+1))
+            self.specified_shift += Coordinate(rnd)
+
 
         # Set shift for all requests
         for specs_type in [request.array_specs, request.points_specs]:
             for (key, spec) in specs_type.items():
                 roi = spec.roi.shift(self.specified_shift)
+                lcm_voxel_size = self.spec.get_lcm_voxel_size(
+                    request.array_specs.keys())
+                roi = roi.snap_to_grid(lcm_voxel_size, mode='closest')
                 specs_type[key].roi = roi
 
-        logger.debug("{}'th shift selected: {}".format(self.loc_i, self.specified_shift))
+        logger.debug("{}'th ({}) shift selected: {}".format(
+            self.loc_i, self.coordinates[self.loc_i], self.specified_shift))
 
     def process(self, batch, request):
         # reset ROIs to request
@@ -119,14 +141,15 @@ class SpecifiedLocation(BatchFilter):
                 batch.points[points_key].data[point_id].location -= self.specified_shift
 
     def _get_next_shift(self, center_shift):
-        # gets next corrdinate from list
+        # gets next coordinate from list
 
         if self.choose_randomly:
-            next_shift = choice(self.coordinates) - center_shift
+            self.loc_i = randrange(len(self.coordinates))
         else:
-            next_shift = Coordinate(self.coordinates[self.loc_i] - center_shift)
             self.loc_i += 1
             if self.loc_i >= len(self.coordinates):
                 self.loc_i = 0
                 logger.warning('Ran out of specified locations, looping list')
+
+        next_shift = Coordinate(self.coordinates[self.loc_i] - center_shift)
         return next_shift

--- a/gunpowder/nodes/specified_location.py
+++ b/gunpowder/nodes/specified_location.py
@@ -101,7 +101,8 @@ class SpecifiedLocation(BatchFilter):
         logger.debug("valid shifts for request in " + str(shift_roi))
 
         # shift to center
-        center_shift = spec.roi.get_shape()/2 + spec.roi.get_offset()
+        total_roi = request.get_total_roi()
+        center_shift = total_roi.get_shape()/2 + total_roi.get_offset()
 
         self.specified_shift = self._get_next_shift(center_shift)
         if self.jitter is not None:

--- a/tests/cases/specified_location.py
+++ b/tests/cases/specified_location.py
@@ -1,0 +1,144 @@
+# from .provider_test import ProviderTest, TestSource
+from gunpowder import (BatchProvider, ArrayKeys, ArraySpec, Roi, Batch,
+                       Coordinate, SpecifiedLocation, build,
+                       BatchRequest, Array, ArrayKey)
+import numpy as np
+import unittest
+
+
+class TestSourceSpecifiedLocation(BatchProvider):
+    def __init__(self, roi, voxel_size):
+        self.voxel_size = Coordinate(voxel_size)
+        self.roi = roi
+        size = self.roi.get_shape() / self.voxel_size
+        self.data = np.arange(np.prod(size)).reshape(size)
+
+    def setup(self):
+        self.provides(
+            ArrayKeys.RAW,
+            ArraySpec(
+                roi=self.roi,
+                voxel_size=self.voxel_size))
+
+    def provide(self, request):
+        batch = Batch()
+
+        spec = request[ArrayKeys.RAW].copy()
+        spec.voxel_size = self.voxel_size
+        size = spec.roi.get_shape() / spec.voxel_size
+        offset = spec.roi.get_offset() / spec.voxel_size
+        slce = tuple(slice(o, o + s) for o, s in zip(offset, size))
+
+        batch.arrays[ArrayKeys.RAW] = Array(
+            data=self.data[slce],
+            spec=spec)
+
+        return batch
+
+
+class TestSpecifiedLocation(unittest.TestCase):
+
+    def setUp(self):
+        ArrayKey('RAW')
+
+    def test_simple(self):
+
+        locations = [
+                [0, 0, 0],
+                [100, 100, 100],
+                [91, 20, 20],
+                [42, 24, 57]
+                ]
+
+        pipeline = (
+            TestSourceSpecifiedLocation(
+                roi=Roi((0, 0, 0), (100, 100, 100)),
+                voxel_size=(1, 1, 1)) +
+            SpecifiedLocation(
+                locations,
+                choose_randomly=False,
+                extra_data=None,
+                jitter=None)
+        )
+
+        with build(pipeline):
+
+            batch = pipeline.request_batch(
+                BatchRequest(
+                    {
+                        ArrayKeys.RAW: ArraySpec(
+                            roi=Roi((0, 0, 0), (20, 20, 20)))
+                    }))
+            # first three locations are skipped
+            # fourth should start at [32, 14, 47] of self.data
+            self.assertEqual(batch.arrays[ArrayKeys.RAW].data[0, 0, 0], 321447)
+
+    def test_voxel_size(self):
+
+        locations = [
+                [0, 0, 0],
+                [91, 20, 20],
+                [42, 24, 57]
+                ]
+
+        pipeline = (
+            TestSourceSpecifiedLocation(
+                roi=Roi((0, 0, 0), (100, 100, 100)),
+                voxel_size=(5, 2, 2)) +
+            SpecifiedLocation(
+                locations,
+                choose_randomly=False,
+                extra_data=None,
+                jitter=None)
+        )
+
+        with build(pipeline):
+
+            batch = pipeline.request_batch(
+                BatchRequest(
+                    {
+                        ArrayKeys.RAW: ArraySpec(
+                            roi=Roi((0, 0, 0), (20, 20, 20)))
+                    }))
+            # first locations is skipped
+            # second should start at [80/5, 10/2, 10/2] = [16, 5, 5]
+            self.assertEqual(batch.arrays[ArrayKeys.RAW].data[0, 0, 0], 40255)
+
+            batch = pipeline.request_batch(
+                BatchRequest(
+                    {
+                        ArrayKeys.RAW: ArraySpec(
+                            roi=Roi((0, 0, 0), (20, 20, 20)))
+                    }))
+            # third should start at [30/5, 14/2, 48/2] = [6, 7, 23]
+            self.assertEqual(batch.arrays[ArrayKeys.RAW].data[0, 0, 0], 15374)
+
+    def test_jitter_and_random(self):
+
+        locations = [
+                [0, 0, 0],
+                [91, 20, 20],
+                [42, 24, 57]
+                ]
+
+        pipeline = (
+            TestSourceSpecifiedLocation(
+                roi=Roi((0, 0, 0), (100, 100, 100)),
+                voxel_size=(5, 2, 2)) +
+            SpecifiedLocation(
+                locations,
+                choose_randomly=True,
+                extra_data=None,
+                jitter=(5, 5, 5))
+        )
+
+        with build(pipeline):
+
+            batch = pipeline.request_batch(
+                BatchRequest(
+                    {
+                        ArrayKeys.RAW: ArraySpec(
+                            roi=Roi((0, 0, 0), (20, 20, 20)))
+                    }))
+            # Unclear what result should be, so no errors means passing
+            self.assertTrue(batch.arrays[ArrayKeys.RAW].data[0, 0, 0] > 0)


### PR DESCRIPTION
Now the specified location node centers the location in the middle of the total roi (rather than an arbitrary request roi). It also checks to see if the shifted roi is inside the provided roi for each request spec, and ensures that the shift is a multiple of the LCM voxel size, rather than snapping to each voxel grid separately, which could cause different shifts for different arrays.