### PR TITLE
set random seed at start of each worker process

### DIFF
--- a/gunpowder/producer_pool.py
+++ b/gunpowder/producer_pool.py
@@ -9,6 +9,8 @@ import sys
 import time
 import traceback
 
+import numpy as np
+
 logger = logging.getLogger(__name__)
 
 class NoResult(Exception):
@@ -120,6 +122,7 @@ class ProducerPool(object):
         logger.debug("parent PID " + str(parent_pid))
 
         result = None
+        np.random.seed(None)
         while True:
 
             if os.getppid() != parent_pid:


### PR DESCRIPTION
numpy's seed is set at import, when new processes are created
the import is not repeated, thus all have the same seed/give the same
random numbers (this behavior is different from python's random package)
Related to issue #74