### PR TITLE
Implement Placeholders

### DIFF
--- a/gunpowder/array_spec.py
+++ b/gunpowder/array_spec.py
@@ -42,13 +42,15 @@ class ArraySpec(Freezable):
             voxel_size=None,
             interpolatable=None,
             nonspatial=False,
-            dtype=None):
+            dtype=None,
+            placeholder=False):
 
         self.roi = roi
         self.voxel_size = None if voxel_size is None else Coordinate(voxel_size)
         self.interpolatable = interpolatable
         self.nonspatial = nonspatial
         self.dtype = dtype
+        self.placeholder = placeholder
 
         if nonspatial:
             assert roi is None, "Non-spatial arrays can not have a ROI"
@@ -79,5 +81,6 @@ class ArraySpec(Freezable):
         r += "voxel size: " + str(self.voxel_size) + ", "
         r += "interpolatable: " + str(self.interpolatable) + ", "
         r += "non-spatial: " + str(self.nonspatial) + ", "
-        r += "dtype: " + str(self.dtype)
+        r += "dtype: " + str(self.dtype) + ", "
+        r += "placeholder: " + str(self.placeholder)
         return r

--- a/gunpowder/batch_provider_tree.py
+++ b/gunpowder/batch_provider_tree.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 class BatchProviderTree(BatchProvider):
 
+    _remove_placeholders = False
+
     def __init__(self, inputs=None, output=None):
         self.inputs = inputs
         self.output = output

--- a/gunpowder/batch_request.py
+++ b/gunpowder/batch_request.py
@@ -16,7 +16,7 @@ class BatchRequest(ProviderSpec):
     batch.
     '''
 
-    def add(self, key, shape, voxel_size=None):
+    def add(self, key, shape, voxel_size=None, placeholder=False):
         '''Convenience method to add an array or graph spec by providing only
         the shape of a ROI (in world units).
 
@@ -41,9 +41,9 @@ class BatchRequest(ProviderSpec):
         '''
 
         if isinstance(key, ArrayKey):
-            spec = ArraySpec()
+            spec = ArraySpec(placeholder=placeholder)
         elif isinstance(key, GraphKey):
-            spec = GraphSpec()
+            spec = GraphSpec(placeholder=placeholder)
         else:
             raise RuntimeError("Only ArrayKey or GraphKey can be added.")
 

--- a/gunpowder/graph_spec.py
+++ b/gunpowder/graph_spec.py
@@ -21,11 +21,12 @@ class GraphSpec(Freezable):
             Whether the graph is directed or not.
     """
 
-    def __init__(self, roi=None, directed=True, dtype=np.float32):
+    def __init__(self, roi=None, directed=True, dtype=np.float32, placeholder=False):
 
         self.roi = roi
         self.directed = directed
         self.dtype = dtype
+        self.placeholder = placeholder
 
         self.freeze()
 
@@ -47,5 +48,8 @@ class GraphSpec(Freezable):
 
     def __repr__(self):
         r = ""
-        r += "ROI: " + str(self.roi)
+        r += "ROI: " + str(self.roi) + ", "
+        r += "dtype: " + str(self.dtype) + ", "
+        r += "directed: " + str(self.directed) + ", "
+        r += "placeholder: " + str(self.placeholder)
         return r

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -34,7 +34,11 @@ class BatchFilter(BatchProvider):
             :func:`process`. Used to communicate dependencies.
     """
 
-    remove_placeholders = True
+    @property
+    def remove_placeholders(self):
+        if not hasattr(self, '_remove_placeholders'):
+            return False
+        return self._remove_placeholders
 
     def get_upstream_provider(self):
         assert (

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -146,9 +146,11 @@ class BatchFilter(BatchProvider):
 
         if not skip:
             if dependencies is not None:
+                dependencies.remove_placeholders()
                 node_batch = batch.crop(dependencies)
             else:
                 node_batch = batch
+            downstream_request.remove_placeholders()
             processed_batch = self.process(node_batch, downstream_request)
             if processed_batch is None:
                 processed_batch = node_batch

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -139,9 +139,9 @@ class BatchFilter(BatchProvider):
                     "containing its dependencies.",
                 )
                 upstream_request = request.copy()
-            self.remove_provided(upstream_request)
         else:
             upstream_request = request.copy()
+        self.remove_provided(upstream_request)
 
         timing_prepare.stop()
 
@@ -177,7 +177,9 @@ class BatchFilter(BatchProvider):
         if not self.autoskip_enabled:
             return False
 
-        for key, _ in request.items():
+        for key, spec in request.items():
+            if spec.placeholder:
+                continue
             if key in self.provided_items:
                 return False
             if key in self.updated_items:

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -34,6 +34,8 @@ class BatchFilter(BatchProvider):
             :func:`process`. Used to communicate dependencies.
     """
 
+    remove_placeholders=True
+
     def get_upstream_provider(self):
         assert (
             len(self.get_upstream_providers()) == 1

--- a/gunpowder/nodes/batch_filter.py
+++ b/gunpowder/nodes/batch_filter.py
@@ -34,7 +34,7 @@ class BatchFilter(BatchProvider):
             :func:`process`. Used to communicate dependencies.
     """
 
-    remove_placeholders=True
+    remove_placeholders = True
 
     def get_upstream_provider(self):
         assert (

--- a/gunpowder/nodes/batch_provider.py
+++ b/gunpowder/nodes/batch_provider.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import itertools
 from gunpowder.coordinate import Coordinate
 from gunpowder.points_spec import PointsSpec
 from gunpowder.provider_spec import ProviderSpec
@@ -24,6 +25,8 @@ class BatchProvider(object):
     exactly one upstream provider, consider subclassing :class:`BatchFilter`
     instead.
     '''
+
+    remove_placeholders = True
 
     def add_upstream_provider(self, provider):
         self.get_upstream_providers().append(provider)
@@ -146,7 +149,10 @@ class BatchProvider(object):
 
         self.check_request_consistency(request)
 
-        batch = self.provide(request.copy())
+        upstream_request = request.copy()
+        if self.remove_placeholders:
+            upstream_request.remove_placeholders()
+        batch = self.provide(upstream_request)
 
         self.check_batch_consistency(batch, request)
 
@@ -267,6 +273,9 @@ class BatchProvider(object):
         for key in batch_keys:
             if key not in request:
                 del batch[key]
+
+    def enable_placeholders(self):
+        self.remove_placeholders = False
 
     def provide(self, request):
         '''To be implemented in subclasses.

--- a/gunpowder/nodes/batch_provider.py
+++ b/gunpowder/nodes/batch_provider.py
@@ -1,12 +1,12 @@
 import copy
 import logging
-import itertools
 from gunpowder.coordinate import Coordinate
 from gunpowder.points_spec import PointsSpec
 from gunpowder.provider_spec import ProviderSpec
 from gunpowder.array import ArrayKey
 from gunpowder.array_spec import ArraySpec
 from gunpowder.graph_spec import GraphSpec
+from gunpowder.batch import Batch
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,10 @@ class BatchProvider(object):
         upstream_request = request.copy()
         if self.remove_placeholders:
             upstream_request.remove_placeholders()
-        batch = self.provide(upstream_request)
+        if len(upstream_request) == 0:
+            batch = Batch()
+        else:
+            batch = self.provide(upstream_request)
 
         self.check_batch_consistency(batch, request)
 

--- a/gunpowder/nodes/batch_provider.py
+++ b/gunpowder/nodes/batch_provider.py
@@ -26,8 +26,6 @@ class BatchProvider(object):
     instead.
     '''
 
-    remove_placeholders = True
-
     def add_upstream_provider(self, provider):
         self.get_upstream_providers().append(provider)
         return provider
@@ -36,6 +34,12 @@ class BatchProvider(object):
         if not hasattr(self, 'upstream_providers'):
             self.upstream_providers = []
         return self.upstream_providers
+
+    @property
+    def remove_placeholders(self):
+        if not hasattr(self, '_remove_placeholders'):
+            return True
+        return self._remove_placeholders
 
     def setup(self):
         '''To be implemented in subclasses.
@@ -156,6 +160,8 @@ class BatchProvider(object):
             batch = Batch()
         else:
             batch = self.provide(upstream_request)
+
+        request.remove_placeholders()
 
         self.check_batch_consistency(batch, request)
 
@@ -278,7 +284,7 @@ class BatchProvider(object):
                 del batch[key]
 
     def enable_placeholders(self):
-        self.remove_placeholders = False
+        self._remove_placeholders = False
 
     def provide(self, request):
         '''To be implemented in subclasses.

--- a/gunpowder/nodes/elastic_augment.py
+++ b/gunpowder/nodes/elastic_augment.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import math
 import numpy as np
@@ -10,6 +9,7 @@ from gunpowder.batch_request import BatchRequest
 from gunpowder.coordinate import Coordinate
 from gunpowder.ext import augment
 from gunpowder.roi import Roi
+from gunpowder.array import ArrayKey
 
 logger = logging.getLogger(__name__)
 
@@ -353,6 +353,9 @@ class ElasticAugment(BatchFilter):
                                 array_key, self.spec[array_key].voxel_size,
                                 prev, self.spec[prev].voxel_size)
             prev = array_key
+
+        if voxel_size is None:
+            raise RuntimeError("voxel size must not be None")
 
         return voxel_size
 

--- a/gunpowder/nodes/merge_provider.py
+++ b/gunpowder/nodes/merge_provider.py
@@ -18,6 +18,7 @@ class MergeProvider(BatchProvider):
         self.key_to_provider = {}
 
     def setup(self):
+        self.enable_placeholders()
         assert len(self.get_upstream_providers()) > 0, "at least one batch provider needs to be added to the MergeProvider"
         # Only allow merging if no two upstream_providers have the same
         # array/points keys

--- a/gunpowder/nodes/random_provider.py
+++ b/gunpowder/nodes/random_provider.py
@@ -29,7 +29,7 @@ class RandomProvider(BatchProvider):
                                   self.probabilities]
 
     def setup(self):
-
+        self.enable_placeholders()
         assert len(self.get_upstream_providers()) > 0,\
             "at least one batch provider must be added to the RandomProvider"
         if self.probabilities is not None:

--- a/gunpowder/provider_spec.py
+++ b/gunpowder/provider_spec.py
@@ -160,6 +160,10 @@ class ProviderSpec(Freezable):
                 "Only ArrayKey or GraphKey can be used as keys in a "
                 "%s."%type(self).__name__)
 
+    def remove_placeholders(self):
+        self.array_specs = {k: v for k, v in self.array_specs if not v.placeholder}
+        self.graph_specs = {k: v for k, v in self.graph_specs if not v.placeholder}
+
     def items(self):
         '''Provides a generator iterating over key/value pairs.'''
 

--- a/gunpowder/provider_spec.py
+++ b/gunpowder/provider_spec.py
@@ -161,8 +161,8 @@ class ProviderSpec(Freezable):
                 "%s."%type(self).__name__)
 
     def remove_placeholders(self):
-        self.array_specs = {k: v for k, v in self.array_specs if not v.placeholder}
-        self.graph_specs = {k: v for k, v in self.graph_specs if not v.placeholder}
+        self.array_specs = {k: v for k, v in self.array_specs.items() if not v.placeholder}
+        self.graph_specs = {k: v for k, v in self.graph_specs.items() if not v.placeholder}
 
     def items(self):
         '''Provides a generator iterating over key/value pairs.'''

--- a/tests/cases/placeholder_requests.py
+++ b/tests/cases/placeholder_requests.py
@@ -1,0 +1,168 @@
+from gunpowder import (
+    BatchProvider,
+    BatchRequest,
+    Batch,
+    Roi,
+    Coordinate,
+    PointsSpec,
+    PointsKey,
+    ArrayKeys,
+    ArrayKey,
+    ArraySpec,
+    Array,
+    ElasticAugment,
+    RandomLocation,
+    Snapshot,
+    build,
+)
+from gunpowder.points import Points, PointsKeys, Point
+from .provider_test import ProviderTest
+
+import pytest
+import numpy as np
+
+import math
+import copy
+
+
+class PointTestSource3D(BatchProvider):
+    def setup(self):
+
+        self.points = {
+            0: Point([0, 10, 0]),
+            1: Point([0, 30, 0]),
+            2: Point([0, 50, 0]),
+            3: Point([0, 70, 0]),
+            4: Point([0, 90, 0]),
+        }
+
+        self.provides(
+            PointsKeys.TEST_POINTS,
+            PointsSpec(roi=Roi((-100, -100, -100), (300, 300, 300))),
+        )
+
+        self.provides(
+            ArrayKeys.TEST_LABELS,
+            ArraySpec(
+                roi=Roi((-100, -100, -100), (300, 300, 300)),
+                voxel_size=Coordinate((4, 1, 1)),
+                interpolatable=False,
+            ),
+        )
+
+    def point_to_voxel(self, array_roi, location):
+
+        # location is in world units, get it into voxels
+        location = location / self.spec[ArrayKeys.TEST_LABELS].voxel_size
+
+        # shift location relative to beginning of array roi
+        location -= array_roi.get_begin() / self.spec[ArrayKeys.TEST_LABELS].voxel_size
+
+        return tuple(slice(int(l - 2), int(l + 3)) for l in location)
+
+    def provide(self, request):
+
+        batch = Batch()
+
+        if PointsKeys.TEST_POINTS in request:
+            roi_points = request[PointsKeys.TEST_POINTS].roi
+
+            points = {}
+            for i, point in self.points.items():
+                if roi_points.contains(point.location):
+                    points[i] = copy.deepcopy(point)
+            batch.points[PointsKeys.TEST_POINTS] = Points(
+                points, PointsSpec(roi=roi_points)
+            )
+
+        if ArrayKeys.TEST_LABELS in request:
+            roi_array = request[ArrayKeys.TEST_LABELS].roi
+            roi_voxel = roi_array // self.spec[ArrayKeys.TEST_LABELS].voxel_size
+
+            data = np.zeros(roi_voxel.get_shape(), dtype=np.uint32)
+            data[:, ::2] = 100
+
+            for i, point in self.points.items():
+                loc = self.point_to_voxel(roi_array, point.location)
+                data[loc] = i
+
+            spec = self.spec[ArrayKeys.TEST_LABELS].copy()
+            spec.roi = roi_array
+            batch.arrays[ArrayKeys.TEST_LABELS] = Array(data, spec=spec)
+
+        return batch
+
+
+class TestPlaceholderRequest(ProviderTest):
+    def test_without_placeholder(self):
+
+        test_labels = ArrayKey("TEST_LABELS")
+        test_points = PointsKey("TEST_POINTS")
+
+        pipeline = (
+            PointTestSource3D()
+            + RandomLocation(ensure_nonempty=test_points)
+            + ElasticAugment([10, 10, 10], [0.1, 0.1, 0.1], [0, 2.0 * math.pi])
+            + Snapshot(
+                {test_labels: "volumes/labels"},
+                output_dir=self.path_to(),
+                output_filename="elastic_augment_test{id}-{iteration}.hdf",
+            )
+        )
+
+        with build(pipeline):
+            for i in range(100):
+
+                request_size = Coordinate((40, 40, 40))
+
+                request_a = BatchRequest(random_seed=i)
+                request_a.add(test_points, request_size)
+
+                request_b = BatchRequest(random_seed=i)
+                request_b.add(test_points, request_size)
+                request_b.add(test_labels, request_size)
+
+                # No array to provide a voxel size to ElasticAugment
+                with pytest.raises(RuntimeError):
+                    pipeline.request_batch(request_a)
+                batch_b = pipeline.request_batch(request_b)
+
+                self.assertIn(test_labels, batch_b)
+
+    def test_placeholder(self):
+
+        test_labels = ArrayKey("TEST_LABELS")
+        test_points = PointsKey("TEST_POINTS")
+
+        pipeline = (
+            PointTestSource3D()
+            + RandomLocation(ensure_nonempty=test_points)
+            + ElasticAugment([10, 10, 10], [0.1, 0.1, 0.1], [0, 2.0 * math.pi])
+            + Snapshot(
+                {test_labels: "volumes/labels"},
+                output_dir=self.path_to(),
+                output_filename="elastic_augment_test{id}-{iteration}.hdf",
+            )
+        )
+
+        with build(pipeline):
+            for i in range(100):
+
+                request_size = Coordinate((40, 40, 40))
+
+                request_a = BatchRequest(random_seed=i)
+                request_a.add(test_points, request_size)
+                request_a.add(test_labels, request_size, placeholder=True)
+
+                request_b = BatchRequest(random_seed=i)
+                request_b.add(test_points, request_size)
+                request_b.add(test_labels, request_size)
+
+                batch_a = pipeline.request_batch(request_a)
+                batch_b = pipeline.request_batch(request_b)
+
+                points_a = batch_a[test_points].nodes
+                points_b = batch_b[test_points].nodes
+
+                for a, b in zip(points_a, points_b):
+                    assert all(np.isclose(a.location, b.location))


### PR DESCRIPTION
Add support for placeholders in BatchRequests.
ArraySpecs and GraphSpecs can both be marked as placeholders.
Placeholders are specs that are added to your request that contain important meta data,
but will not result in actually reading data. For example, you may want a RandomLocation
with the `ensure_nonempty` flag, however not actually need the points for anything.

`BatchProviders` will remove placeholders before passing the request to `process` unless
opted in with `enable_placeholders` in the `setup` method.
`BatchFilters` by default will provide placeholders as part of the request during the `prepare`
method, but not the `process` method.