### PR TITLE
Patch 1.1.3

### DIFF
--- a/gunpowder/nodes/normalize.py
+++ b/gunpowder/nodes/normalize.py
@@ -53,6 +53,7 @@ class Normalize(BatchFilter):
 
         factor = self.factor
         array = batch.arrays[self.array]
+        array.spec.dtype = self.dtype
 
         if factor is None:
 

--- a/gunpowder/nodes/random_location.py
+++ b/gunpowder/nodes/random_location.py
@@ -202,7 +202,6 @@ class RandomLocation(BatchFilter):
             # Add +1 in voxel size to allow for all possible shifts
             lcm_voxel_size = self.spec.get_lcm_voxel_size(
                 request.array_specs.keys())
-            logger.debug(f'{lcm_voxel_size=}')
             shift_roi = shift_roi.grow(
                 (0,) * request_roi.dims(),
                 lcm_voxel_size

--- a/gunpowder/nodes/random_location.py
+++ b/gunpowder/nodes/random_location.py
@@ -199,6 +199,15 @@ class RandomLocation(BatchFilter):
                 -request_roi.get_shape()
             )
 
+            # Add +1 in voxel size to allow for all possible shifts
+            lcm_voxel_size = self.spec.get_lcm_voxel_size(
+                request.array_specs.keys())
+            logger.debug(f'{lcm_voxel_size=}')
+            shift_roi = shift_roi.grow(
+                (0,) * request_roi.dims(),
+                lcm_voxel_size
+            )
+
             if total_shift_roi is None:
                 total_shift_roi = shift_roi
             else:

--- a/gunpowder/torch/nodes/train.py
+++ b/gunpowder/torch/nodes/train.py
@@ -318,7 +318,7 @@ class Train(GenericTrain):
 
         for array_name, array_key in reference.items():
             if isinstance(array_key, ArrayKey):
-                msg = "batch does not contain {array_key}, array {array_name} will not be set"
+                msg = f"batch does not contain {array_key}, array {array_name} will not be set"
                 if array_key in batch.arrays:
                     arrays[array_name] = batch.arrays[array_key].data
                 elif not expect_missing_arrays:

--- a/tests/cases/random_location.py
+++ b/tests/cases/random_location.py
@@ -1,6 +1,19 @@
-from .provider_test import ProviderTest
-from gunpowder import *
 import numpy as np
+
+from .provider_test import ProviderTest
+from gunpowder import (
+    RandomLocation,
+    BatchProvider,
+    Roi,
+    Coordinate,
+    ArrayKey,
+    ArrayKeys,
+    ArraySpec,
+    Batch,
+    Array,
+    BatchRequest,
+    build,
+)
 
 
 class TestSourceRandomLocation(BatchProvider):
@@ -63,11 +76,12 @@ class TestRandomLocation(ProviderTest):
 
                 self.assertTrue(np.sum(batch.arrays[ArrayKeys.RAW].data) > 0)
 
-                # Request the entire ROI from the source
+                # Request a ROI with the same shape as the entire ROI
+                full_roi = Roi((0, 0, 0), source.roi.get_shape())
                 batch = pipeline.request_batch(
                     BatchRequest(
                         {
-                            ArrayKeys.RAW: ArraySpec(roi=source.roi)
+                            ArrayKeys.RAW: ArraySpec(roi=full_roi)
                         }
                     )
                 )


### PR DESCRIPTION
Main bug fix: `RandomLocation` did not work when its request had the same shape as the upstream dataset.

Two additional non-essential bugs.

