### PR TITLE
RandomLocation: Preserve offsets for empty shift ROIs

### DIFF
--- a/gunpowder/nodes/random_location.py
+++ b/gunpowder/nodes/random_location.py
@@ -202,7 +202,8 @@ class RandomLocation(BatchFilter):
             if total_shift_roi is None:
                 total_shift_roi = shift_roi
             else:
-                total_shift_roi = total_shift_roi.intersect(shift_roi)
+                if shift_roi != total_shift_roi:
+                    total_shift_roi = total_shift_roi.intersect(shift_roi)
 
         logger.debug("valid shifts for request in " + str(total_shift_roi))
 


### PR DESCRIPTION
The updated version of RandomLocation from patch-1.1.3 does not work if you request the entire upstream ROI for more than one array (refer to ba72ac2853f4d50a32dd71876952545a3b86ff4e). 

The reason is that it uses the intersect method in `Roi`,  which does not preserve offsets when intersecting empty ROIs. This feature seems reasonable in general and I therefore added it.

Alternatively, the offset preservation could be implemented directly in `RandomLocation.__get_possible_shifts`.