### PR TITLE
Add nodes for squeezing and unsqueezing arrays

### DIFF
--- a/gunpowder/nodes/__init__.py
+++ b/gunpowder/nodes/__init__.py
@@ -34,7 +34,9 @@ from .shift_augment import ShiftAugment
 from .simple_augment import SimpleAugment
 from .snapshot import Snapshot
 from .specified_location import SpecifiedLocation
+from .squeeze import Squeeze
 from .stack import Stack
+from .unsqueeze import Unsqueeze
 from .upsample import UpSample
 from .zarr_source import ZarrSource
 from .zarr_write import ZarrWrite

--- a/gunpowder/nodes/squeeze.py
+++ b/gunpowder/nodes/squeeze.py
@@ -1,0 +1,49 @@
+import copy
+from typing import List
+import logging
+
+import numpy as np
+
+from gunpowder.array import ArrayKey
+from gunpowder.batch_request import BatchRequest
+from gunpowder.batch import Batch
+from .batch_filter import BatchFilter
+
+logger = logging.getLogger(__name__)
+
+
+class Squeeze(BatchFilter):
+    """Squeeze a batch at a given axis
+
+    Args:
+        arrays (List[ArrayKey]): ArrayKeys to squeeze.
+        axis: Position of the single-dimensional axis to remove, defaults to 0.
+    """
+
+    def __init__(self, arrays: List[ArrayKey], axis: int = 0):
+        self.arrays = arrays
+        self.axis = axis
+
+        if self.axis != 0:
+            raise NotImplementedError(
+                'Squeeze only supported for leading dimension')
+
+    def setup(self):
+        self.enable_autoskip()
+        for array in self.arrays:
+            self.updates(array, self.spec[array].copy())
+
+    def prepare(self, request):
+        deps = BatchRequest()
+        for array in self.arrays:
+            deps[array] = request[array].copy()
+        return deps
+
+    def process(self, batch, request):
+        outputs = Batch()
+        for array in self.arrays:
+            outputs[array] = copy.deepcopy(batch[array])
+            outputs[array].data = np.squeeze(batch[array].data, self.axis)
+            logger.debug(f'{array} shape: {outputs[array].data.shape}')
+
+        return outputs

--- a/gunpowder/nodes/unsqueeze.py
+++ b/gunpowder/nodes/unsqueeze.py
@@ -1,0 +1,48 @@
+import copy
+from typing import List
+import logging
+
+import numpy as np
+
+from .batch_filter import BatchFilter
+from gunpowder.array import ArrayKey
+from gunpowder.batch import Batch
+from gunpowder.batch_request import BatchRequest
+
+
+logger = logging.getLogger(__name__)
+
+
+class Unsqueeze(BatchFilter):
+    """Unsqueeze a batch at a given axis
+
+    Args:
+        arrays (List[ArrayKey]): ArrayKeys to unsqueeze.
+        axis: Position where the new axis is placed, defaults to 0.
+    """
+
+    def __init__(self, arrays: List[ArrayKey], axis: int = 0):
+        self.arrays = arrays
+        self.axis = axis
+
+        if self.axis != 0:
+            raise NotImplementedError(
+                'Unsqueeze only supported for leading dimension')
+
+    def setup(self):
+        self.enable_autoskip()
+        for array in self.arrays:
+            self.updates(array, self.spec[array].copy())
+
+    def prepare(self, request):
+        deps = BatchRequest()
+        for array in self.arrays:
+            deps[array] = request[array].copy()
+        return deps
+
+    def process(self, batch, request):
+        outputs = Batch()
+        for array in self.arrays:
+            outputs[array] = copy.deepcopy(batch[array])
+            outputs[array].data = np.expand_dims(batch[array].data, self.axis)
+        return outputs

--- a/tests/cases/squeeze.py
+++ b/tests/cases/squeeze.py
@@ -1,0 +1,101 @@
+import copy
+import numpy as np
+import gunpowder as gp
+
+import fiborganellesegmentation as fos
+
+from .provider_test import ProviderTest
+
+
+class TestSourceSqueeze(gp.BatchProvider):
+    def __init__(self, voxel_size):
+        self.voxel_size = gp.Coordinate(voxel_size)
+        self.roi = gp.Roi((0, 0, 0), (10, 10, 10)) * self.voxel_size
+
+        self.raw = gp.ArrayKey("RAW")
+        self.labels = gp.ArrayKey("LABELS")
+
+        self.array_spec_raw = gp.ArraySpec(
+            roi=self.roi,
+            voxel_size=self.voxel_size,
+            dtype='uint8',
+            interpolatable=True
+        )
+
+        self.array_spec_labels = gp.ArraySpec(
+            roi=self.roi,
+            voxel_size=self.voxel_size,
+            dtype='uint64',
+            interpolatable=False
+        )
+
+    def setup(self):
+
+        self.provides(self.raw, self.array_spec_raw)
+        self.provides(self.labels, self.array_spec_labels)
+
+    def provide(self, request):
+        outputs = gp.Batch()
+
+        # RAW
+        raw_spec = copy.deepcopy(self.array_spec_raw)
+        raw_spec.roi = request[self.raw].roi
+
+        raw_shape = request[self.raw].roi.get_shape() / self.voxel_size
+
+        outputs[self.raw] = gp.Array(
+            np.random.randint(
+                0,
+                256,
+                raw_shape,
+                dtype=raw_spec.dtype
+            ),
+            raw_spec
+        )
+
+        # Unsqueeze
+        outputs[self.raw].data = np.expand_dims(outputs[self.raw].data, axis=0)
+        outputs[self.raw].data = np.expand_dims(outputs[self.raw].data, axis=0)
+
+        # LABELS
+        labels_spec = copy.deepcopy(self.array_spec_labels)
+        labels_spec.roi = request[self.labels].roi
+
+        labels_shape = request[self.labels].roi.get_shape() / self.voxel_size
+
+        labels = np.ones(
+            labels_shape,
+            dtype=labels_spec.dtype
+        )
+        outputs[self.labels] = gp.Array(labels, labels_spec)
+
+        # Unsqueeze
+        outputs[self.labels].data = np.expand_dims(
+            outputs[self.labels].data, axis=0)
+
+        return outputs
+
+
+class TestSqueeze:
+    def test_squeeze(self):
+        raw = gp.ArrayKey("RAW")
+        labels = gp.ArrayKey("LABELS")
+
+        voxel_size = gp.Coordinate((50, 5, 5))
+        input_voxels = gp.Coordinate((10, 10, 10))
+        input_size = input_voxels * voxel_size
+
+        request = gp.BatchRequest()
+        request.add(raw, input_size)
+        request.add(labels, input_size)
+
+        pipeline = (
+            TestSourceSqueeze(voxel_size)
+            + fos.gunpowder.Squeeze([raw], axis=0)
+            + fos.gunpowder.Squeeze([raw, labels])
+        )
+
+        with gp.build(pipeline) as p:
+            batch = p.request_batch(request)
+            assert batch[raw].data.shape == input_voxels
+            assert batch[labels].data.shape == input_voxels

--- a/tests/cases/unsqueeze.py
+++ b/tests/cases/unsqueeze.py
@@ -1,0 +1,92 @@
+import copy
+import numpy as np
+import gunpowder as gp
+
+import fiborganellesegmentation as fos
+from .provider_test import ProviderTest
+
+
+class TestSourceUnsqueeze(gp.BatchProvider):
+    def __init__(self, voxel_size):
+        self.voxel_size = gp.Coordinate(voxel_size)
+        self.roi = gp.Roi((0, 0, 0), (10, 10, 10)) * self.voxel_size
+
+        self.raw = gp.ArrayKey("RAW")
+        self.labels = gp.ArrayKey("LABELS")
+
+        self.array_spec_raw = gp.ArraySpec(
+            roi=self.roi,
+            voxel_size=self.voxel_size,
+            dtype='uint8',
+            interpolatable=True
+        )
+
+        self.array_spec_labels = gp.ArraySpec(
+            roi=self.roi,
+            voxel_size=self.voxel_size,
+            dtype='uint64',
+            interpolatable=False
+        )
+
+    def setup(self):
+
+        self.provides(self.raw, self.array_spec_raw)
+        self.provides(self.labels, self.array_spec_labels)
+
+    def provide(self, request):
+        outputs = gp.Batch()
+
+        # RAW
+        raw_spec = copy.deepcopy(self.array_spec_raw)
+        raw_spec.roi = request[self.raw].roi
+
+        raw_shape = request[self.raw].roi.get_shape() / self.voxel_size
+
+        outputs[self.raw] = gp.Array(
+            np.random.randint(
+                0,
+                256,
+                raw_shape,
+                dtype=raw_spec.dtype
+            ),
+            raw_spec
+        )
+
+        # LABELS
+        labels_spec = copy.deepcopy(self.array_spec_labels)
+        labels_spec.roi = request[self.labels].roi
+
+        labels_shape = request[self.labels].roi.get_shape() / self.voxel_size
+
+        labels = np.ones(
+            labels_shape,
+            dtype=labels_spec.dtype
+        )
+        outputs[self.labels] = gp.Array(labels, labels_spec)
+
+        return outputs
+
+
+class TestUnsqueeze(ProviderTest):
+    def test_unsqueeze(self):
+        raw = gp.ArrayKey("RAW")
+        labels = gp.ArrayKey("LABELS")
+
+        voxel_size = gp.Coordinate((50, 5, 5))
+        input_voxels = gp.Coordinate((10, 10, 10))
+        input_size = input_voxels * voxel_size
+
+        request = gp.BatchRequest()
+        request.add(raw, input_size)
+        request.add(labels, input_size)
+
+        pipeline = (
+            TestSourceUnsqueeze(voxel_size)
+            + fos.gunpowder.Unsqueeze([raw], axis=0)
+            + fos.gunpowder.Unsqueeze([raw, labels])
+        )
+
+        with gp.build(pipeline) as p:
+            batch = p.request_batch(request)
+            assert batch[raw].data.shape == (1,) + (1,) + input_voxels
+            assert batch[labels].data.shape == (1,) + input_voxels


### PR DESCRIPTION
These nodes are necessary to prepare a `Batch` for `torch.Train`, as it requires an additional minit-batch dimension and a channel dimension. I added the parameter `axis`, but limited its value to the default `0` for now, as unsqueezing intermediate dimensions leads to issues with `Array` handling.