### PR TITLE
Fix SimpleAugment upstream request

### DIFF
--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -54,7 +54,7 @@ class SimpleAugment(BatchFilter):
     def prepare(self, request):
 
         self.mirror = [
-            random.randint(0,1)
+            random.randint(0, 1)
             if self.mirror_mask[d] else 0
             for d in range(self.dims)
         ]
@@ -67,12 +67,6 @@ class SimpleAugment(BatchFilter):
 
         logger.debug("mirror = " + str(self.mirror))
         logger.debug("transpose = " + str(self.transpose))
-
-        reverse_transpose = [0]*self.dims
-        for d in range(self.dims):
-            reverse_transpose[self.transpose[d]] = d
-        logger.debug("reverse_transpose: ", reverse_transpose,
-                     "transpose: ", self.transpose)
 
         logger.debug("downstream request = " + str(request) +
                      "\nmirror = " + str(self.mirror) +

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -117,7 +117,7 @@ class SimpleAugment(BatchFilter):
             array.data = array.data[channel_slices + mirror]
 
             transpose = [t + num_channels for t in self.transpose]
-            array.data = array.data.transpose(tuple(range(num_channels)) + transpose)
+            array.data = array.data.transpose(list(range(num_channels)) + transpose)
 
         # graphs
         total_roi_offset = batch.get_total_roi().get_offset()

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -79,7 +79,6 @@ class SimpleAugment(BatchFilter):
                      "\ntranspose = " + str(self.transpose))
 
         self.__mirror_request(request, self.mirror)
-        logger.debug("modified downstream request = " + str(request)) 
 
         logger.debug("upstream request = " + str(request))
 

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -117,7 +117,7 @@ class SimpleAugment(BatchFilter):
             array.data = array.data[channel_slices + mirror]
 
             transpose = [t + num_channels for t in self.transpose]
-            array.data = array.data.transpose([0]*num_channels + transpose)
+            array.data = array.data.transpose(tuple(range(num_channels)) + transpose)
 
         # graphs
         total_roi_offset = batch.get_total_roi().get_offset()

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -78,8 +78,6 @@ class SimpleAugment(BatchFilter):
                      "\nmirror = " + str(self.mirror) +
                      "\ntranspose = " + str(self.transpose))
 
-        self.__mirror_request(request, self.mirror)
-
         logger.debug("upstream request = " + str(request))
 
         return request
@@ -143,13 +141,6 @@ class SimpleAugment(BatchFilter):
                 if not graph.spec.roi.contains(node.location):
                     graph.remove_node(node)
             logger.debug("nodes left: ", len(list(graph.nodes)), "with ", self.transpose)
-
-
-    def __mirror_request(self, request, mirror):
-
-        for key, spec in request.items():
-            if spec.roi is not None:
-                self.__mirror_roi(spec.roi, request.get_total_roi(), mirror)
 
     def __mirror_roi(self, roi, total_roi, mirror):
 

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -30,4 +30,4 @@ from .torch_train import TestTorchTrain, TestTorchPredict
 from .upsample import TestUpSample
 from .zarr_write import TestZarrWrite
 from .snapshot import TestSnapshot
-from .simple_augment import SimpleAugment
+from .simple_augment import TestSimpleAugment

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -17,15 +17,15 @@ from gunpowder import (
 )
 
 import numpy as np
-
+from itertools import permutations 
 
 class TestSource(BatchProvider):
     def __init__(self):
 
         self.graph = Graph(
-            [Node(id=1, location=np.array([1, 1, 1]))],
+            [Node(id=1, location=np.array([1, 34, 65]))],
             [],
-            GraphSpec(roi=Roi((0, 0, 0), (100, 100, 100))),
+            GraphSpec(roi=Roi((0, 20, 33), (100, 120, 178))),
         )
 
     def setup(self):
@@ -40,13 +40,14 @@ class TestSource(BatchProvider):
         batch = Batch()
 
         roi = request[GraphKeys.TEST_GRAPH].roi
+        print("roi: ", roi)
         batch[GraphKeys.TEST_GRAPH] = self.graph.crop(roi).trim(roi)
 
         return batch
 
 
 class TestSimpleAugment(ProviderTest):
-    def test_simple(self):
+    def test_mirror(self):
         test_graph = GraphKey("TEST_GRAPH")
 
         pipeline = TestSource() + SimpleAugment(
@@ -54,8 +55,8 @@ class TestSimpleAugment(ProviderTest):
         )
 
         request = BatchRequest()
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 0, 0), (100, 100, 100)))
-
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
+        possible_loc = [[1, 99], [34, 106], [65, 121]]
         with build(pipeline):
             seen_mirrored = False
             for i in range(100):
@@ -63,13 +64,146 @@ class TestSimpleAugment(ProviderTest):
 
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
                 node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                print(node.location)
                 assert all(
                     [
-                        node.location[dim] == 1 or node.location[dim] == 99
+                        node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
                         for dim in range(3)
                     ]
                 )
+                print(node.location)
                 seen_mirrored = seen_mirrored or any(
-                    [node.location[dim] == 99 for dim in range(3)]
+                    [node.location[dim] == possible_loc[dim][1] for dim in range(3)]
                 )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
             assert seen_mirrored
+
+
+    def test_two_transpose(self):
+        test_graph = GraphKey("TEST_GRAPH")
+
+        transpose_dims = [1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=[], transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
+
+        possible_loc = [[1, 1], [34, 52], [65, 47]]
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                print(node.location)
+                assert all(
+                    [
+                        node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
+                        for dim in range(3)
+                    ]
+                )
+                print(node.location)
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != possible_loc[dim][0] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed
+
+    def test_multi_transpose(self):
+        test_graph = GraphKey("TEST_GRAPH")
+        point = np.array([1, 34, 65])
+
+        transpose_dims = [0, 1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=[], transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        offset = (0, 20, 33)
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+
+        # Create all possible permurations of our transpose dims
+        transpose_combinations = list(permutations(transpose_dims, 3))
+        possible_loc = np.zeros((len(transpose_combinations), 3))
+
+        # Transpose points in all possible ways
+        for i, comb in enumerate(transpose_combinations):
+            possible_loc[i] = point - np.array(offset)
+            possible_loc[i] = possible_loc[i][np.array(comb)]
+            possible_loc[i] = possible_loc[i] + np.array(offset)
+
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+
+                assert node.location in possible_loc 
+
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != point[dim] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed
+
+    def test_both(self):
+        test_graph = GraphKey("TEST_GRAPH")
+        og_point = np.array([1, 34, 65])
+
+        transpose_dims = [0, 1, 2]
+        mirror_dims = [0, 1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=mirror_dims, transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        offset = (0, 20, 33)
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+        
+        # Get all possble mirror locations
+        # possible_mirror_loc = [[1, 99], [34, 106], [65, 121]]
+        mirror_combs = [[1, 34, 65],
+                        [1, 106, 121],
+                        [1, 34, 121],
+                        [1, 106, 65],
+                        [99, 34, 65],
+                        [99, 106, 121],
+                        [99, 34, 121],
+                        [99, 106, 65]]
+
+        # Create all possible permurations of our transpose dims
+        transpose_combinations = list(permutations(transpose_dims, 3))
+
+        # Generate all possible tranposes of all possible mirrors
+        possible_loc = np.zeros((len(mirror_combs), len(transpose_combinations), 3))
+        for i, point in enumerate(mirror_combs): 
+            for j, comb in enumerate(transpose_combinations):
+                possible_loc[i, j] = point - np.array(offset)
+                possible_loc[i, j] = possible_loc[i, j][np.array(comb)]
+                possible_loc[i, j] = possible_loc[i, j] + np.array(offset)
+        print(possible_loc)
+
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+
+                # Check if your location is possible
+                assert node.location in possible_loc 
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != og_point[dim] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -18,6 +18,7 @@ from gunpowder import (
 
 import numpy as np
 from itertools import permutations 
+import logging
 
 class TestSource(BatchProvider):
     def __init__(self):
@@ -40,7 +41,7 @@ class TestSource(BatchProvider):
         batch = Batch()
 
         roi = request[GraphKeys.TEST_GRAPH].roi
-        print("roi: ", roi)
+        logging.debug("roi: ", roi)
         batch[GraphKeys.TEST_GRAPH] = self.graph.crop(roi).trim(roi)
 
         return batch
@@ -64,14 +65,14 @@ class TestSimpleAugment(ProviderTest):
 
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
                 node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-                print(node.location)
+                logging.debug(node.location)
                 assert all(
                     [
                         node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
                         for dim in range(3)
                     ]
                 )
-                print(node.location)
+                logging.debug(node.location)
                 seen_mirrored = seen_mirrored or any(
                     [node.location[dim] == possible_loc[dim][1] for dim in range(3)]
                 )
@@ -99,14 +100,14 @@ class TestSimpleAugment(ProviderTest):
 
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
                 node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-                print(node.location)
+                logging.debug(node.location)
                 assert all(
                     [
                         node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
                         for dim in range(3)
                     ]
                 )
-                print(node.location)
+                logging.debug(node.location)
                 seen_transposed = seen_transposed or any(
                     [node.location[dim] != possible_loc[dim][0] for dim in range(3)]
                 )
@@ -189,7 +190,6 @@ class TestSimpleAugment(ProviderTest):
                 possible_loc[i, j] = point - np.array(offset)
                 possible_loc[i, j] = possible_loc[i, j][np.array(comb)]
                 possible_loc[i, j] = possible_loc[i, j] + np.array(offset)
-        print(possible_loc)
 
         with build(pipeline):
             seen_transposed = False


### PR DESCRIPTION
Old tranpose:
1. Prepare: Request transposed ROI !Problem
2. Process: Tranpose ROI back to fit Request !Covers up problem 1
3. Process: Transpose array data
4. Proces: Transpose location data with respect to source ROI !Problem

When requesting a tranposed ROI the source does not get tranposed, instead
the ROI request is just shifted and it gets data from a different part of
the source than was requested by SimpleAugment's downstread node.
The Roi is then tranposed back to fit the original request, but still
has the data from the translated ROI.

The points are then tranposed with respect to the global source by
just filping the ROI dims. This is an issue because we already tranposed
the ROI back to the downstream request so locations can be outside of
the request dim.

New tranpose:
1. Prepare: Use downsteam reqest
2. Transpose array data
3. Tranpose graph locations with respect to the batch's total ROI

This change will also no longer change request with respect to the mirror, 
for the same reasons as the transpose change.

This way we request the spot on the source that the downstream node
wanted, and point locations are not placed incorrectly.

Added 3 tests and improved existing mirror test.

Some tests make all possible permuations of mirror/transposes to ensure
tranposed and mirrored locations are put in expected locations.