### PR TITLE
Transpose around center in SimpleAugment

### DIFF
--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -189,25 +189,25 @@ class SimpleAugment(BatchFilter):
 
     def __transpose_roi(self, roi, transpose):
         
-        logger.debug("Original roi: %s"%roi)
+        logger.debug(f"Original roi: {roi}")
 
         total_roi_offset = self.total_roi.get_offset()
-        logger.debug("total_roi_offset: " + str(total_roi_offset))
+        logger.debug(f"total_roi_offset: {total_roi_offset}")
 
         center = self.total_roi.get_center()
-        logger.debug("Center: %s" + str(center))
+        logger.debug(f"Center: {center}")
 
         # Get distance from center, then transpose
         dist_to_center = center - roi.get_offset() 
         dist_to_center = Coordinate(dist_to_center[transpose[d]]
                                     for d in range(self.dims))
-        logger.debug("dist_to_center: " + str(dist_to_center))
+        logger.debug(f"dist_to_center: {dist_to_center}")
 
         # Using the tranposed distance to center, get the correct offset.
         new_offset = center - dist_to_center
-        logger.debug("shift: " + str(new_offset))
+        logger.debug(f"new_offset: {new_offset}")
 
         shape = tuple(roi.get_shape()[transpose[d]] for d in range(self.dims))
         roi.set_offset(new_offset)
         roi.set_shape(shape)
-        logger.debug("Tranposed roi: %s"%roi)
+        logger.debug(f"Tranposed roi: {roi}")

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -53,8 +53,6 @@ class SimpleAugment(BatchFilter):
 
     def prepare(self, request):
 
-        self.total_roi = request.get_total_roi().copy()
-
         self.mirror = [
             random.randint(0,1)
             if self.mirror_mask[d] else 0
@@ -99,7 +97,7 @@ class SimpleAugment(BatchFilter):
                 logger.debug("upstream %s ROI: %s"%(key, collector.spec.roi))
                 self.__mirror_roi(collector.spec.roi, total_roi, self.mirror)
                 logger.debug("mirrored %s ROI: %s"%(key,collector.spec.roi))
-                self.__transpose_roi(collector.spec.roi, self.transpose)
+                self.__transpose_roi(collector.spec.roi, total_roi, self.transpose)
                 logger.debug("transposed %s ROI: %s"%(key,collector.spec.roi))
 
         mirror = tuple(
@@ -157,9 +155,10 @@ class SimpleAugment(BatchFilter):
                 self.__mirror_roi(spec.roi, request.get_total_roi(), mirror)
 
     def __transpose_request(self, request, transpose):
+        total_roi = request.get_total_roi().copy()
         for key, spec in request.items():
             if spec.roi is not None:
-                self.__transpose_roi(spec.roi, transpose)
+                self.__transpose_roi(spec.roi, total_roi, transpose)
 
     def __mirror_roi(self, roi, total_roi, mirror):
 
@@ -187,14 +186,11 @@ class SimpleAugment(BatchFilter):
 
         roi.set_offset(roi_offset)
 
-    def __transpose_roi(self, roi, transpose):
+    def __transpose_roi(self, roi, total_roi, transpose):
         
         logger.debug(f"Original roi: {roi}")
 
-        total_roi_offset = self.total_roi.get_offset()
-        logger.debug(f"total_roi_offset: {total_roi_offset}")
-
-        center = self.total_roi.get_center()
+        center = total_roi.get_center()
         logger.debug(f"Center: {center}")
 
         # Get distance from center, then transpose

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -121,7 +121,7 @@ class SimpleAugment(BatchFilter):
             array.data = array.data[channel_slices + mirror]
 
             transpose = [t + num_channels for t in self.transpose]
-            array.data = array.data.transpose([0]*num_channels + transpose)
+            array.data = array.data = array.data.transpose(list(range(num_channels)) + transpose)
 
         # graphs
         total_roi_offset = batch.get_total_roi().get_offset()

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -30,4 +30,4 @@ from .torch_train import TestTorchTrain, TestTorchPredict
 from .upsample import TestUpSample
 from .zarr_write import TestZarrWrite
 from .snapshot import TestSnapshot
-from .simple_augment import SimpleAugment
+from .simple_augment import TestSimpleAugment

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -149,7 +149,6 @@ class TestSimpleAugment(ProviderTest):
                     assert batch.arrays[array_key].data.shape == batch.arrays[array_key].spec.roi.get_shape()
 
             assert seen_transposed
-            assert 1==2
 
     def test_multi_transpose(self):
         test_graph = GraphKey("TEST_GRAPH")

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -17,15 +17,17 @@ from gunpowder import (
 )
 
 import numpy as np
-
+from itertools import permutations 
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 class TestSource(BatchProvider):
     def __init__(self):
 
         self.graph = Graph(
-            [Node(id=1, location=np.array([1, 1, 1]))],
+            [Node(id=1, location=np.array([1, 34, 65]))],
             [],
-            GraphSpec(roi=Roi((0, 0, 0), (100, 100, 100))),
+            GraphSpec(roi=Roi((-10, 0, 0), (120, 130, 178))),
         )
 
     def setup(self):
@@ -40,13 +42,14 @@ class TestSource(BatchProvider):
         batch = Batch()
 
         roi = request[GraphKeys.TEST_GRAPH].roi
+        #logging.debug("roi: ", roi)
         batch[GraphKeys.TEST_GRAPH] = self.graph.crop(roi).trim(roi)
 
         return batch
 
 
 class TestSimpleAugment(ProviderTest):
-    def test_simple(self):
+    def test_mirror(self):
         test_graph = GraphKey("TEST_GRAPH")
 
         pipeline = TestSource() + SimpleAugment(
@@ -54,8 +57,8 @@ class TestSimpleAugment(ProviderTest):
         )
 
         request = BatchRequest()
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 0, 0), (100, 100, 100)))
-
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
+        possible_loc = [[1, 99], [34, 106], [65, 121]]
         with build(pipeline):
             seen_mirrored = False
             for i in range(100):
@@ -63,13 +66,143 @@ class TestSimpleAugment(ProviderTest):
 
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
                 node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                logging.debug(node.location)
                 assert all(
                     [
-                        node.location[dim] == 1 or node.location[dim] == 99
+                        node.location[dim] in possible_loc[dim] 
                         for dim in range(3)
                     ]
                 )
                 seen_mirrored = seen_mirrored or any(
-                    [node.location[dim] == 99 for dim in range(3)]
+                    [node.location[dim] == possible_loc[dim][1] for dim in range(3)]
                 )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
             assert seen_mirrored
+
+
+    def test_two_transpose(self):
+        test_graph = GraphKey("TEST_GRAPH")
+
+        transpose_dims = [1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=[], transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
+
+        possible_loc = [[1, 1], [34, 52], [65, 47]]
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                logging.debug(node.location)
+                assert all(
+                    [
+                        node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
+                        for dim in range(3)
+                    ]
+                )
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != possible_loc[dim][0] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed
+
+    def test_multi_transpose(self):
+        test_graph = GraphKey("TEST_GRAPH")
+        point = np.array([1, 34, 65])
+
+        transpose_dims = [0, 1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=[], transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        offset = (0, 20, 33)
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+
+        # Create all possible permurations of our transpose dims
+        transpose_combinations = list(permutations(transpose_dims, 3))
+        possible_loc = np.zeros((len(transpose_combinations), 3))
+
+        # Transpose points in all possible ways
+        for i, comb in enumerate(transpose_combinations):
+            possible_loc[i] = point - np.array(offset)
+            possible_loc[i] = possible_loc[i][np.array(comb)]
+            possible_loc[i] = possible_loc[i] + np.array(offset)
+
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+
+                assert node.location in possible_loc 
+
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != point[dim] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed
+
+    def test_both(self):
+        test_graph = GraphKey("TEST_GRAPH")
+        og_point = np.array([1, 34, 65])
+
+        transpose_dims = [0, 1, 2]
+        mirror_dims = [0, 1, 2]
+        pipeline = TestSource() + SimpleAugment(
+            mirror_only=mirror_dims, transpose_only=transpose_dims
+        )
+
+        request = BatchRequest()
+        offset = (0, 20, 33)
+        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+        
+        # Get all possble mirror locations
+        # possible_mirror_loc = [[1, 99], [34, 106], [65, 121]]
+        mirror_combs = [[1, 34, 65],
+                        [1, 106, 121],
+                        [1, 34, 121],
+                        [1, 106, 65],
+                        [99, 34, 65],
+                        [99, 106, 121],
+                        [99, 34, 121],
+                        [99, 106, 65]]
+
+        # Create all possible permurations of our transpose dims
+        transpose_combinations = list(permutations(transpose_dims, 3))
+
+        # Generate all possible tranposes of all possible mirrors
+        possible_loc = np.zeros((len(mirror_combs), len(transpose_combinations), 3))
+        for i, point in enumerate(mirror_combs): 
+            for j, comb in enumerate(transpose_combinations):
+                possible_loc[i, j] = point - np.array(offset)
+                possible_loc[i, j] = possible_loc[i, j][np.array(comb)]
+                possible_loc[i, j] = possible_loc[i, j] + np.array(offset)
+
+        with build(pipeline):
+            seen_transposed = False
+            for i in range(100):
+                batch = pipeline.request_batch(request)
+
+                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+
+                # Check if your location is possible
+                assert node.location in possible_loc 
+                seen_transposed = seen_transposed or any(
+                    [node.location[dim] != og_point[dim] for dim in range(3)]
+                )
+                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+            assert seen_transposed

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -7,6 +7,7 @@ from gunpowder import (
     Graph,
     Node,
     GraphSpec,
+    ArraySpec,
     Roi,
     BatchProvider,
     BatchRequest,
@@ -14,20 +15,49 @@ from gunpowder import (
     GraphKey,
     Batch,
     SimpleAugment,
+    Array,
+    ArrayKey,
+    MergeProvider,
+    Pad
 )
 
 import numpy as np
 from itertools import permutations 
 import logging
-logging.basicConfig(level=logging.DEBUG)
+
+
+class ArrayTestSource(BatchProvider):
+    def __init__(self):
+        spec = ArraySpec(roi=Roi((-200, -200, -200), (600, 600, 600)), dtype=np.float64, voxel_size=(1, 1, 1))
+        self.array = Array(np.zeros(spec.roi.get_shape()), spec=spec) 
+
+    def setup(self):
+
+        self.provides(ArrayKeys.TEST_ARRAY1, self.array.spec)
+        self.provides(ArrayKeys.TEST_ARRAY2, self.array.spec)
+
+    def prepare(self, request):
+        return request
+
+    def provide(self, request):
+
+        batch = Batch()
+
+        roi1 = request[ArrayKeys.TEST_ARRAY1].roi
+        roi2 = request[ArrayKeys.TEST_ARRAY2].roi
+
+        batch[ArrayKeys.TEST_ARRAY1] = self.array.crop(roi1)
+        batch[ArrayKeys.TEST_ARRAY2] = self.array.crop(roi2)
+
+        return batch
 
 class TestSource(BatchProvider):
     def __init__(self):
 
         self.graph = Graph(
-            [Node(id=1, location=np.array([1, 34, 65]))],
+            [Node(id=1, location=np.array([50, 70, 100]))],
             [],
-            GraphSpec(roi=Roi((-10, 0, 0), (120, 130, 178))),
+            GraphSpec(roi=Roi((-200, -200, -200), (400, 400, 478))),
         )
 
     def setup(self):
@@ -42,7 +72,6 @@ class TestSource(BatchProvider):
         batch = Batch()
 
         roi = request[GraphKeys.TEST_GRAPH].roi
-        #logging.debug("roi: ", roi)
         batch[GraphKeys.TEST_GRAPH] = self.graph.crop(roi).trim(roi)
 
         return batch
@@ -58,7 +87,7 @@ class TestSimpleAugment(ProviderTest):
 
         request = BatchRequest()
         request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
-        possible_loc = [[1, 99], [34, 106], [65, 121]]
+        possible_loc = [[50, 49], [70, 29], [100, 86]]
         with build(pipeline):
             seen_mirrored = False
             for i in range(100):
@@ -83,27 +112,31 @@ class TestSimpleAugment(ProviderTest):
 
     def test_two_transpose(self):
         test_graph = GraphKey("TEST_GRAPH")
+        test_array1 = ArrayKey("TEST_ARRAY1")
+        test_array2 = ArrayKey("TEST_ARRAY2")
 
         transpose_dims = [1, 2]
-        pipeline = TestSource() + SimpleAugment(
+        pipeline = (ArrayTestSource(), TestSource()) + MergeProvider() + SimpleAugment(
             mirror_only=[], transpose_only=transpose_dims
         )
 
         request = BatchRequest()
         request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
+        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
+        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(roi=Roi((0, 100, 250), (100, 100, 50)))
+                
 
-        possible_loc = [[1, 1], [34, 52], [65, 47]]
+        possible_loc = [[50, 50], [70, 100], [100, 70]]
         with build(pipeline):
             seen_transposed = False
             for i in range(100):
                 batch = pipeline.request_batch(request)
-
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
                 node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
                 logging.debug(node.location)
                 assert all(
                     [
-                        node.location[dim] in possible_loc[dim] or node.location[dim] in possible_loc[dim] 
+                        node.location[dim] in possible_loc[dim] 
                         for dim in range(3)
                     ]
                 )
@@ -112,20 +145,26 @@ class TestSimpleAugment(ProviderTest):
                 )
                 assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
                 assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+
+
             assert seen_transposed
 
     def test_multi_transpose(self):
         test_graph = GraphKey("TEST_GRAPH")
-        point = np.array([1, 34, 65])
+        test_array1 = ArrayKey("TEST_ARRAY1")
+        test_array2 = ArrayKey("TEST_ARRAY2")
+        point = np.array([50, 70, 100])
 
         transpose_dims = [0, 1, 2]
-        pipeline = TestSource() + SimpleAugment(
+        pipeline = (ArrayTestSource(), TestSource()) + MergeProvider() + SimpleAugment(
             mirror_only=[], transpose_only=transpose_dims
         )
 
         request = BatchRequest()
         offset = (0, 20, 33)
         request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
+        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(roi=Roi((0, 100, 250), (100, 100, 50)))
 
         # Create all possible permurations of our transpose dims
         transpose_combinations = list(permutations(transpose_dims, 3))
@@ -133,51 +172,59 @@ class TestSimpleAugment(ProviderTest):
 
         # Transpose points in all possible ways
         for i, comb in enumerate(transpose_combinations):
-            possible_loc[i] = point - np.array(offset)
-            possible_loc[i] = possible_loc[i][np.array(comb)]
-            possible_loc[i] = possible_loc[i] + np.array(offset)
+            possible_loc[i] = point[np.array(comb)]
 
         with build(pipeline):
             seen_transposed = False
+            seen_node = True
             for i in range(100):
                 batch = pipeline.request_batch(request)
 
-                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
-                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                if len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1:
+                    seen_node = True
+                    node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
 
-                assert node.location in possible_loc 
+                    assert node.location in possible_loc 
 
-                seen_transposed = seen_transposed or any(
-                    [node.location[dim] != point[dim] for dim in range(3)]
-                )
-                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
-                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+                    seen_transposed = seen_transposed or any(
+                        [node.location[dim] != point[dim] for dim in range(3)]
+                    )
+                    assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                    assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+
             assert seen_transposed
+            assert seen_node
 
     def test_both(self):
         test_graph = GraphKey("TEST_GRAPH")
-        og_point = np.array([1, 34, 65])
+        test_array1 = ArrayKey("TEST_ARRAY1")
+        test_array2 = ArrayKey("TEST_ARRAY2")
+        og_point = np.array([50, 70, 100])
 
         transpose_dims = [0, 1, 2]
         mirror_dims = [0, 1, 2]
-        pipeline = TestSource() + SimpleAugment(
+        pipeline = ((ArrayTestSource(), TestSource()) + MergeProvider() + 
+                    Pad(test_array1, None) + Pad(test_array2, None) + Pad(test_graph, None)
+                    + SimpleAugment(
             mirror_only=mirror_dims, transpose_only=transpose_dims
-        )
+        ))
 
         request = BatchRequest()
         offset = (0, 20, 33)
         request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
+        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
+        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(roi=Roi((0, 100, 250), (100, 100, 50)))
         
         # Get all possble mirror locations
-        # possible_mirror_loc = [[1, 99], [34, 106], [65, 121]]
-        mirror_combs = [[1, 34, 65],
-                        [1, 106, 121],
-                        [1, 34, 121],
-                        [1, 106, 65],
-                        [99, 34, 65],
-                        [99, 106, 121],
-                        [99, 34, 121],
-                        [99, 106, 65]]
+        # possible_mirror_loc = [[49, 50], [70, 29], [100, 86]]
+        mirror_combs = [[49, 70, 100],
+                        [49, 29, 86],
+                        [49, 70, 86],
+                        [49, 29, 100],
+                        [50, 70, 100],
+                        [50, 29, 86],
+                        [50, 70, 86],
+                        [50, 29, 100]]
 
         # Create all possible permurations of our transpose dims
         transpose_combinations = list(permutations(transpose_dims, 3))
@@ -186,23 +233,25 @@ class TestSimpleAugment(ProviderTest):
         possible_loc = np.zeros((len(mirror_combs), len(transpose_combinations), 3))
         for i, point in enumerate(mirror_combs): 
             for j, comb in enumerate(transpose_combinations):
-                possible_loc[i, j] = point - np.array(offset)
-                possible_loc[i, j] = possible_loc[i, j][np.array(comb)]
-                possible_loc[i, j] = possible_loc[i, j] + np.array(offset)
+                possible_loc[i, j] = np.array(point)[np.array(comb)]
 
         with build(pipeline):
             seen_transposed = False
+            seen_node = True
             for i in range(100):
                 batch = pipeline.request_batch(request)
 
-                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
-                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
+                if len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1:
+                    seen_node = True
+                    node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
 
-                # Check if your location is possible
-                assert node.location in possible_loc 
-                seen_transposed = seen_transposed or any(
-                    [node.location[dim] != og_point[dim] for dim in range(3)]
-                )
-                assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
-                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+                    # Check if your location is possible
+                    assert node.location in possible_loc 
+                    seen_transposed = seen_transposed or any(
+                        [node.location[dim] != og_point[dim] for dim in range(3)]
+                    )
+                    assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
+                    assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
+
             assert seen_transposed
+            assert seen_node

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -24,7 +24,6 @@ from gunpowder import (
 import numpy as np
 from itertools import permutations 
 import logging
-logging.getLogger("gunpowder.nodes.simple_augment").setLevel(logging.DEBUG)
 
 class ArrayTestSource(BatchProvider):
     def __init__(self):
@@ -146,8 +145,11 @@ class TestSimpleAugment(ProviderTest):
                 assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
                 assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
 
+                for (array_key, array) in batch.arrays.items():
+                    assert batch.arrays[array_key].data.shape == batch.arrays[array_key].spec.roi.get_shape()
 
             assert seen_transposed
+            assert 1==2
 
     def test_multi_transpose(self):
         test_graph = GraphKey("TEST_GRAPH")
@@ -192,6 +194,8 @@ class TestSimpleAugment(ProviderTest):
                     assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
                     assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
 
+                for (array_key, array) in batch.arrays.items():
+                    assert batch.arrays[array_key].data.shape == batch.arrays[array_key].spec.roi.get_shape()
             assert seen_transposed
             assert seen_node
 
@@ -253,6 +257,8 @@ class TestSimpleAugment(ProviderTest):
                     assert Roi((0, 20, 33), (100, 100, 120)).contains(batch[GraphKeys.TEST_GRAPH].spec.roi)
                     assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
 
+                for (array_key, array) in batch.arrays.items():
+                    assert batch.arrays[array_key].data.shape == batch.arrays[array_key].spec.roi.get_shape()
             assert seen_transposed
             assert seen_node
 
@@ -278,5 +284,7 @@ class TestSimpleAugment(ProviderTest):
         with build(pipeline):
             for i in range(100):
                 batch = pipeline.request_batch(request)
-                print(batch)
                 assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
+
+                for (array_key, array) in batch.arrays.items():
+                    assert batch.arrays[array_key].data.shape == batch.arrays[array_key].spec.roi.get_shape()


### PR DESCRIPTION
Rather than transposing the request offsets, it should transpose around the center of the downstream request.

Old functionality:
Source with (1000, 2000)
Downstream request for array of size (20, 40) with ROI (90:110, 1480:1520).
Transpose request and make upstream request for (1480:1520, 90:110)

This request would then be very far out of bounds and very far from the original requested area.

New functionality:
Source with (1000, 2000)
Downstream request for array of size (20, 40) with ROI (90:110, 1480:1520).
Calculate center: (100, 1500)
Calculate distance of offset from center: (10, 20)
Transpose distance: (20, 10), because we want our new request to have transposed shape
Subtract distance from center to get new offset (80, 1490)
Transpose shape: (40, 20)
Request ROI of (80:120, 1490:1510)

Example of rotating around center:
![tranpose](https://user-images.githubusercontent.com/26679938/87103257-84264a80-c222-11ea-920e-d4ad9e92242d.jpeg)
