### PR TITLE
Add hidden nodes to the API reference

### DIFF
--- a/docs/build/api.rst
+++ b/docs/build/api.rst
@@ -137,6 +137,10 @@ IntensityAugment
 ^^^^^^^^^^^^^^^^
   .. autoclass:: IntensityAugment
 
+NoiseAugment
+^^^^^^^^^^^^^^^^
+  .. autoclass:: NoiseAugment
+
 SimpleAugment
 ^^^^^^^^^^^^^
   .. autoclass:: SimpleAugment
@@ -287,6 +291,14 @@ Output Nodes
 Hdf5Write
 ^^^^^^^^^
   .. autoclass:: Hdf5Write
+
+ZarrWrite
+^^^^^^^^^
+  .. autoclass:: ZarrWrite
+
+N5Write
+^^^^^^^^^
+  .. autoclass:: N5Write
 
 .. _sec_api_snapshot:
 


### PR DESCRIPTION
There are some nodes with nice docstrings, but do not show up in the [API reference](http://funkey.science/gunpowder/api.html). I added them to the proper subsections.
There are two more nodes I did not add:
- `DaisyRequestBlocks` (not sure in which API subsection that should go)
- `ShiftAugment` (missing docstring) 