### PR TITLE
ignore interrupts in worker processes

### DIFF
--- a/gunpowder/producer_pool.py
+++ b/gunpowder/producer_pool.py
@@ -5,6 +5,7 @@ except:
 import logging
 import multiprocessing
 import os
+import signal
 import sys
 import time
 import traceback
@@ -122,6 +123,8 @@ class ProducerPool(object):
             logger.info("done")
 
     def __run_worker(self, target):
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         parent_pid = os.getppid()
 

--- a/gunpowder/producer_pool.py
+++ b/gunpowder/producer_pool.py
@@ -84,6 +84,8 @@ class ProducerPool(object):
         self.__watch_dog = None
 
     def __run_watch_dog(self, callables):
+        
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         parent_pid = os.getppid()
 


### PR DESCRIPTION
ignore interrupt signals (eg keyboard interrupt) in worker processes,
let it propagate to parent process.