### PR TITLE
scan: lower bound max_shift by min_shift

### DIFF
--- a/gunpowder/nodes/scan.py
+++ b/gunpowder/nodes/scan.py
@@ -252,7 +252,8 @@ class Scan(BatchFilter):
         in this dimension.'''
 
         min_shift = shift_roi.get_offset()
-        max_shift = Coordinate(m - 1 for m in shift_roi.get_end())
+        max_shift = max(min_shift,
+                        Coordinate(m - 1 for m in shift_roi.get_end()))
 
         shift = np.array(min_shift)
         shifts = []


### PR DESCRIPTION
bug if maximally possible shift in one dimension is 0
roi: get_end == get_offset -> max_shift = min_shift -> m-1 is smaller than min_shift