### PR TITLE
random_loc: shifts are valid if at least one coordinate is non-zero

### DIFF
--- a/gunpowder/nodes/random_location.py
+++ b/gunpowder/nodes/random_location.py
@@ -242,7 +242,7 @@ class RandomLocation(BatchFilter):
         assert not total_shift_roi.unbounded() or self.ensure_nonempty is not None, (
             "Can not pick a random location, intersection of upstream ROIs is "
             "unbounded.")
-        assert total_shift_roi.get_begin() is not None, (
+        assert sum(total_shift_roi.get_shape()) > 0, (
             "Can not satisfy batch request, no location covers all requested "
             "ROIs.")
 

--- a/gunpowder/roi.py
+++ b/gunpowder/roi.py
@@ -196,9 +196,6 @@ class Roi(Freezable):
 
         assert self.dims() == other.dims()
 
-        if self.empty() or other.empty():
-            return False
-
         # separated if at least one dimension is separated
         separated = any([
             # a dimension is separated if:


### PR DESCRIPTION
roi: remove .empty shortcut in intersects
empty is true if any component in shape is zero.
for random location there can be valid shifts even if a subset of
components are zero (as long as one is non-zero)