### PR TITLE
add #workers/cache to precache log

### DIFF
--- a/gunpowder/nodes/precache.py
+++ b/gunpowder/nodes/precache.py
@@ -91,7 +91,8 @@ class PreCache(BatchFilter):
 
                 self.current_request = copy.deepcopy(request)
 
-                logger.info("starting new set of workers...")
+                logger.info("starting new set of workers (%s, cache size %s)...",
+                            self.num_workers, self.cache_size)
                 self.workers = ProducerPool(
                     [lambda i=i: self.__run_worker(i) for i in range(self.num_workers)],
                     queue_size=self.cache_size,


### PR DESCRIPTION
useful on cluster, in case too many workers for job allocation