### PR TITLE
Make Coordinate add and mul operations commutative

### DIFF
--- a/gunpowder/coordinate.py
+++ b/gunpowder/coordinate.py
@@ -51,6 +51,9 @@ class Coordinate(tuple):
             else None
             for a, b in zip(self, other))
 
+    def __radd__(self, other):
+        return self.__add__(other)
+
     def __sub__(self, other):
 
         assert isinstance(other, tuple), f"can only subtract Coordinate or tuples to Coordinate. {type(other)} is invalid"
@@ -85,6 +88,9 @@ class Coordinate(tuple):
         else:
 
             raise TypeError("multiplication of Coordinate with type %s not supported" %type(other))
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
 
     def __div__(self, other):
 


### PR DESCRIPTION
Coordindates are fixed to consist of integer values.
Therefore, addition and multiplication of Coordinates with integers/tuples should
be commutative to correspond to our intuition.