### PR TITLE
gp Train: train node should add inputs to request

### DIFF
--- a/gunpowder/nodes/generic_train.py
+++ b/gunpowder/nodes/generic_train.py
@@ -117,7 +117,11 @@ class GenericTrain(BatchFilter):
     def prepare(self, request):
         deps = BatchRequest()
         for key in self.inputs.values():
-            deps[key] = request[key]
+            if key in self.array_specs:
+                deps[key] = self.array_specs[key].copy()
+            else:
+                deps[key] = request[key]
+
         return deps
 
     def teardown(self):


### PR DESCRIPTION
If inputs are not already in request, train node should request
them from upstream.
This way they are not passed on downstream if no downstream
consumer exists.
To do this, add spec for inputs to array_specs

(part of #124)