### PR TITLE
Kainmueller lab v1.2 dev simple augment

### DIFF
--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -157,9 +157,15 @@ class SimpleAugment(BatchFilter):
                 list(range(num_channels)) + transpose)
 
         # graphs
-        total_roi_offset = batch.get_total_roi().get_offset()
-        total_roi_center = batch.get_total_roi().get_center()
-        total_roi_end = batch.get_total_roi().get_end()
+        total_roi_offset = total_roi.get_offset()
+        total_roi_center = total_roi.get_center()
+        if lcm_voxel_size is not None:
+            nearest_voxel_shift = Coordinate(
+                (d % v) for d, v in zip(total_roi_center, lcm_voxel_size)
+            )
+            total_roi_center = total_roi_center - nearest_voxel_shift
+        total_roi_end = total_roi.get_end()
+        logger.debug("augmenting in %s and center %s", total_roi, total_roi_center)
 
         for (graph_key, graph) in batch.graphs.items():
 

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -135,6 +135,7 @@ class SimpleAugment(BatchFilter):
 
         # graphs
         total_roi_offset = batch.get_total_roi().get_offset()
+        total_roi_center = batch.get_total_roi().get_center()
         total_roi_end = batch.get_total_roi().get_end()
 
         for (graph_key, graph) in batch.graphs.items():
@@ -164,13 +165,13 @@ class SimpleAugment(BatchFilter):
                 # transpose
                 location_in_total_offset = (
                     np.asarray(node.location) -
-                    total_roi_offset)
+                    total_roi_center)
 
                 if self.transpose != list(range(self.dims)):
                     for d in range(self.dims):
                         node.location[d] = \
                             location_in_total_offset[self.transpose[d]] + \
-                            total_roi_offset[d]
+                            total_roi_center[d]
 
                 logger.debug("after transpose: %s, %s", node.id, node.location)
 

--- a/gunpowder/nodes/simple_augment.py
+++ b/gunpowder/nodes/simple_augment.py
@@ -181,13 +181,15 @@ class SimpleAugment(BatchFilter):
                 location_in_total_offset = (
                     np.asarray(node.location) -
                     total_roi_offset)
-                node.location[:] = np.asarray(
+                node.location = np.asarray(
                     [
                         total_roi_end[dim] -
                         location_in_total_offset[dim]
                         if m else node.location[dim]
                         for dim, m in enumerate(self.mirror)
-                    ])
+                    ],
+                    dtype=graph.spec.dtype,
+                )
 
                 logger.debug("after mirror: %s, %s", node.id, node.location)
 

--- a/tests/cases/helper_sources.py
+++ b/tests/cases/helper_sources.py
@@ -1,0 +1,33 @@
+from gunpowder import BatchProvider, GraphKey, Graph, ArrayKey, Array, Batch
+
+import copy
+
+
+class ArraySource(BatchProvider):
+    def __init__(self, key: ArrayKey, array: Array):
+        self.key = key
+        self.array = array
+
+    def setup(self):
+        self.provides(self.key, self.array.spec.copy())
+
+    def provide(self, request):
+        outputs = Batch()
+        outputs[self.key] = copy.deepcopy(self.array.crop(request[self.key].roi))
+        return outputs
+
+
+class GraphSource(BatchProvider):
+    def __init__(self, key: GraphKey, graph: Graph):
+        self.key = key
+        self.graph = graph
+
+    def setup(self):
+        self.provides(self.key, self.graph.spec)
+
+    def provide(self, request):
+        outputs = Batch()
+        outputs[self.key] = copy.deepcopy(
+            self.graph.crop(request[self.key].roi).trim(request[self.key].roi)
+        )
+        return outputs

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -96,13 +96,13 @@ def test_transpose():
     default_pipeline = (
         (GraphSource(graph_key, graph), ArraySource(array_key, array))
         + MergeProvider()
-        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=0)
+        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=[0, 0])
     )
 
     transpose_pipeline = (
         (GraphSource(graph_key, graph), ArraySource(array_key, array))
         + MergeProvider()
-        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=1)
+        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=[1, 1])
     )
 
     request = BatchRequest()
@@ -159,7 +159,7 @@ def test_mirror_and_transpose():
             mirror_only=[0, 1],
             transpose_only=[0, 1],
             mirror_probs=[0, 0],
-            transpose_probs=0,
+            transpose_probs={(0, 1): 1},
         )
     )
 
@@ -170,7 +170,7 @@ def test_mirror_and_transpose():
             mirror_only=[0, 1],
             transpose_only=[0, 1],
             mirror_probs=[0, 1],
-            transpose_probs=1,
+            transpose_probs={(1, 0): 1},
         )
     )
 
@@ -246,7 +246,7 @@ def test_mismatched_voxel_multiples():
         ),
     )
     pipeline = source + SimpleAugment(
-        mirror_only=[], transpose_only=[0, 1], transpose_probs=1
+        mirror_only=[], transpose_only=[0, 1], transpose_probs={(1, 0): 1}
     )
 
     with build(pipeline):

--- a/tests/cases/simple_augment.py
+++ b/tests/cases/simple_augment.py
@@ -1,370 +1,208 @@
-from .provider_test import ProviderTest
 from gunpowder import (
-    ArrayKeys,
-    build,
-    Normalize,
-    Graph,
-    Node,
-    GraphSpec,
-    ArraySpec,
-    Roi,
+    Batch,
     BatchProvider,
     BatchRequest,
-    GraphKeys,
-    GraphKey,
-    Batch,
-    SimpleAugment,
     Array,
     ArrayKey,
+    ArraySpec,
+    Graph,
+    GraphKey,
+    GraphSpec,
+    Node,
+    Coordinate,
+    Roi,
+    SimpleAugment,
     MergeProvider,
-    Pad,
-    PipelineRequestError,
+    build,
 )
 
 import numpy as np
-from itertools import permutations
-import logging
+
+from .helper_sources import GraphSource, ArraySource
 
 
-class ArrayTestSource(BatchProvider):
-    def __init__(self):
-        spec = ArraySpec(
-            roi=Roi((-200, -200, -200), (600, 600, 600)),
-            dtype=np.float64,
-            voxel_size=(1, 1, 1),
+def test_mirror():
+    voxel_size = Coordinate((20, 20))
+    graph_key = GraphKey("GRAPH")
+    array_key = ArrayKey("ARRAY")
+    graph = Graph(
+        [Node(id=1, location=np.array([450, 550]))],
+        [],
+        GraphSpec(roi=Roi((100, 200), (800, 600))),
+    )
+    data = np.zeros([40, 30])
+    data[17, 17] = 1
+    array = Array(
+        data, ArraySpec(roi=Roi((100, 200), (800, 600)), voxel_size=voxel_size)
+    )
+
+    default_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(mirror_only=[0, 1], transpose_only=[], mirror_probs=[0, 0])
+    )
+
+    mirror_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(mirror_only=[0, 1], transpose_only=[], mirror_probs=[1, 1])
+    )
+
+    request = BatchRequest()
+    request[graph_key] = GraphSpec(roi=Roi((400, 500), (200, 300)))
+    request[array_key] = ArraySpec(roi=Roi((400, 500), (200, 300)))
+    with build(default_pipeline):
+        expected_location = [450, 550]
+        batch = default_pipeline.request_batch(request)
+
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (node.location - batch[array_key].spec.roi.get_offset()) / voxel_size
         )
-        self.array = Array(np.zeros(spec.roi.get_shape()), spec=spec)
+        assert batch[array_key].data[node_voxel_index] == 1
 
-    def setup(self):
+    with build(mirror_pipeline):
+        expected_location = [550, 750]
+        batch = mirror_pipeline.request_batch(request)
 
-        self.provides(ArrayKeys.TEST_ARRAY1, self.array.spec)
-        self.provides(ArrayKeys.TEST_ARRAY2, self.array.spec)
-
-    def prepare(self, request):
-        return request
-
-    def provide(self, request):
-
-        batch = Batch()
-
-        roi1 = request[ArrayKeys.TEST_ARRAY1].roi
-        roi2 = request[ArrayKeys.TEST_ARRAY2].roi
-
-        batch[ArrayKeys.TEST_ARRAY1] = self.array.crop(roi1)
-        batch[ArrayKeys.TEST_ARRAY2] = self.array.crop(roi2)
-
-        return batch
-
-
-class ExampleSource(BatchProvider):
-    def __init__(self):
-
-        self.graph = Graph(
-            [Node(id=1, location=np.array([50, 70, 100]))],
-            [],
-            GraphSpec(roi=Roi((-200, -200, -200), (400, 400, 478))),
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (node.location - batch[array_key].spec.roi.get_offset()) / voxel_size
         )
-
-    def setup(self):
-
-        self.provides(GraphKeys.TEST_GRAPH, self.graph.spec)
-
-    def prepare(self, request):
-        return request
-
-    def provide(self, request):
-
-        batch = Batch()
-
-        roi = request[GraphKeys.TEST_GRAPH].roi
-        batch[GraphKeys.TEST_GRAPH] = self.graph.crop(roi).trim(roi)
-
-        return batch
+        assert (
+            batch[array_key].data[node_voxel_index] == 1
+        ), f"Node at {np.where(batch[array_key].data == 1)} not {node_voxel_index}"
 
 
-class TestSimpleAugment(ProviderTest):
-    def test_mirror(self):
-        test_graph = GraphKey("TEST_GRAPH")
+def test_transpose():
+    voxel_size = Coordinate((20, 20))
+    graph_key = GraphKey("GRAPH")
+    array_key = ArrayKey("ARRAY")
+    graph = Graph(
+        [Node(id=1, location=np.array([450, 550]))],
+        [],
+        GraphSpec(roi=Roi((100, 200), (800, 600))),
+    )
+    data = np.zeros([40, 30])
+    data[17, 17] = 1
+    array = Array(
+        data, ArraySpec(roi=Roi((100, 200), (800, 600)), voxel_size=voxel_size)
+    )
 
-        pipeline = ExampleSource() + SimpleAugment(
-            mirror_only=[0, 1, 2], transpose_only=[]
+    default_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=0)
+    )
+
+    transpose_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(mirror_only=[], transpose_only=[0, 1], transpose_probs=1)
+    )
+
+    request = BatchRequest()
+    request[graph_key] = GraphSpec(roi=Roi((400, 500), (200, 300)))
+    request[array_key] = ArraySpec(roi=Roi((400, 500), (200, 300)))
+    with build(default_pipeline):
+        expected_location = [450, 550]
+        batch = default_pipeline.request_batch(request)
+
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (node.location - batch[array_key].spec.roi.get_offset()) / voxel_size
         )
+        assert (
+            batch[array_key].data[node_voxel_index] == 1
+        ), f"Node at {np.where(batch[array_key].data == 1)} not {node_voxel_index}"
 
-        request = BatchRequest()
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
-        possible_loc = [[50, 49], [70, 29], [100, 86]]
-        with build(pipeline):
-            seen_mirrored = False
-            for i in range(100):
-                batch = pipeline.request_batch(request)
+    with build(transpose_pipeline):
+        expected_location = [410, 590]
+        batch = transpose_pipeline.request_batch(request)
 
-                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
-                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-                logging.debug(node.location)
-                assert all(
-                    [node.location[dim] in possible_loc[dim] for dim in range(3)]
-                )
-                seen_mirrored = seen_mirrored or any(
-                    [node.location[dim] == possible_loc[dim][1] for dim in range(3)]
-                )
-                assert Roi((0, 20, 33), (100, 100, 120)).contains(
-                    batch[GraphKeys.TEST_GRAPH].spec.roi
-                )
-                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
-            assert seen_mirrored
-
-    def test_two_transpose(self):
-        test_graph = GraphKey("TEST_GRAPH")
-        test_array1 = ArrayKey("TEST_ARRAY1")
-        test_array2 = ArrayKey("TEST_ARRAY2")
-
-        transpose_dims = [1, 2]
-        pipeline = (
-            (ArrayTestSource(), ExampleSource())
-            + MergeProvider()
-            + SimpleAugment(mirror_only=[], transpose_only=transpose_dims)
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (node.location - batch[array_key].spec.roi.get_offset()) / voxel_size
         )
+        assert (
+            batch[array_key].data[node_voxel_index] == 1
+        ), f"Node at {np.where(batch[array_key].data == 1)} not {node_voxel_index}"
 
-        request = BatchRequest()
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 20, 33), (100, 100, 120)))
-        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
-        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(
-            roi=Roi((0, 100, 250), (100, 100, 50))
+
+def test_mirror_and_transpose():
+    voxel_size = Coordinate((20, 20))
+    graph_key = GraphKey("GRAPH")
+    array_key = ArrayKey("ARRAY")
+    graph = Graph(
+        [Node(id=1, location=np.array([450, 550]))],
+        [],
+        GraphSpec(roi=Roi((100, 200), (800, 600))),
+    )
+    data = np.zeros([40, 30])
+    data[17, 17] = 1
+    array = Array(
+        data, ArraySpec(roi=Roi((100, 200), (800, 600)), voxel_size=voxel_size)
+    )
+
+    default_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(
+            mirror_only=[0, 1],
+            transpose_only=[0, 1],
+            mirror_probs=[0, 0],
+            transpose_probs=0,
         )
+    )
 
-        possible_loc = [[50, 50], [70, 100], [100, 70]]
-        with build(pipeline):
-            seen_transposed = False
-            for i in range(100):
-                batch = pipeline.request_batch(request)
-                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
-                node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-                logging.debug(node.location)
-                assert all(
-                    [node.location[dim] in possible_loc[dim] for dim in range(3)]
-                )
-                seen_transposed = seen_transposed or any(
-                    [node.location[dim] != possible_loc[dim][0] for dim in range(3)]
-                )
-                assert Roi((0, 20, 33), (100, 100, 120)).contains(
-                    batch[GraphKeys.TEST_GRAPH].spec.roi
-                )
-                assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
-
-                for (array_key, array) in batch.arrays.items():
-                    assert (
-                        batch.arrays[array_key].data.shape
-                        == batch.arrays[array_key].spec.roi.get_shape()
-                    )
-
-            assert seen_transposed
-
-    def test_multi_transpose(self):
-        test_graph = GraphKey("TEST_GRAPH")
-        test_array1 = ArrayKey("TEST_ARRAY1")
-        test_array2 = ArrayKey("TEST_ARRAY2")
-        point = np.array([50, 70, 100])
-
-        transpose_dims = [0, 1, 2]
-        pipeline = (
-            (ArrayTestSource(), ExampleSource())
-            + MergeProvider()
-            + SimpleAugment(mirror_only=[], transpose_only=transpose_dims)
+    augmented_pipeline = (
+        (GraphSource(graph_key, graph), ArraySource(array_key, array))
+        + MergeProvider()
+        + SimpleAugment(
+            mirror_only=[0, 1],
+            transpose_only=[0, 1],
+            mirror_probs=[0, 1],
+            transpose_probs=1,
         )
+    )
 
-        request = BatchRequest()
-        offset = (0, 20, 33)
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
-        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
-        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(
-            roi=Roi((0, 100, 250), (100, 100, 50))
+    request = BatchRequest()
+    request[graph_key] = GraphSpec(roi=Roi((400, 500), (200, 300)))
+    request[array_key] = ArraySpec(roi=Roi((400, 500), (200, 300)))
+    with build(default_pipeline):
+        expected_location = [450, 550]
+        batch = default_pipeline.request_batch(request)
+
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (node.location - batch[array_key].spec.roi.get_offset()) / voxel_size
         )
+        assert batch[array_key].data[node_voxel_index] == 1
 
-        # Create all possible permurations of our transpose dims
-        transpose_combinations = list(permutations(transpose_dims, 3))
-        possible_loc = np.zeros((len(transpose_combinations), 3))
+    with build(augmented_pipeline):
+        expected_location = [590, 590]
+        batch = augmented_pipeline.request_batch(request)
 
-        # Transpose points in all possible ways
-        for i, comb in enumerate(transpose_combinations):
-            possible_loc[i] = point[np.array(comb)]
-
-        with build(pipeline):
-            seen_transposed = False
-            seen_node = True
-            for i in range(100):
-                batch = pipeline.request_batch(request)
-
-                if len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1:
-                    seen_node = True
-                    node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-
-                    assert node.location in possible_loc
-
-                    seen_transposed = seen_transposed or any(
-                        [node.location[dim] != point[dim] for dim in range(3)]
-                    )
-                    assert Roi((0, 20, 33), (100, 100, 120)).contains(
-                        batch[GraphKeys.TEST_GRAPH].spec.roi
-                    )
-                    assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
-
-                for (array_key, array) in batch.arrays.items():
-                    assert (
-                        batch.arrays[array_key].data.shape
-                        == batch.arrays[array_key].spec.roi.get_shape()
-                    )
-            assert seen_transposed
-            assert seen_node
-
-    def test_both(self):
-        test_graph = GraphKey("TEST_GRAPH")
-        test_array1 = ArrayKey("TEST_ARRAY1")
-        test_array2 = ArrayKey("TEST_ARRAY2")
-        og_point = np.array([50, 70, 100])
-
-        transpose_dims = [0, 1, 2]
-        mirror_dims = [0, 1, 2]
-        pipeline = (
-            (ArrayTestSource(), ExampleSource())
-            + MergeProvider()
-            + Pad(test_array1, None)
-            + Pad(test_array2, None)
-            + Pad(test_graph, None)
-            + SimpleAugment(mirror_only=mirror_dims, transpose_only=transpose_dims)
+        assert len(list(batch[graph_key].nodes)) == 1
+        node = list(batch[graph_key].nodes)[0]
+        assert all(np.isclose(node.location, expected_location))
+        node_voxel_index = Coordinate(
+            (np.array(expected_location) - batch[array_key].spec.roi.get_offset())
+            / voxel_size
         )
-
-        request = BatchRequest()
-        offset = (0, 20, 33)
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi(offset, (100, 100, 120)))
-        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 0), (100, 200, 300)))
-        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(
-            roi=Roi((0, 100, 250), (100, 100, 50))
-        )
-
-        # Get all possble mirror locations
-        # possible_mirror_loc = [[49, 50], [70, 29], [100, 86]]
-        mirror_combs = [
-            [49, 70, 100],
-            [49, 29, 86],
-            [49, 70, 86],
-            [49, 29, 100],
-            [50, 70, 100],
-            [50, 29, 86],
-            [50, 70, 86],
-            [50, 29, 100],
-        ]
-
-        # Create all possible permurations of our transpose dims
-        transpose_combinations = list(permutations(transpose_dims, 3))
-
-        # Generate all possible tranposes of all possible mirrors
-        possible_loc = np.zeros((len(mirror_combs), len(transpose_combinations), 3))
-        for i, point in enumerate(mirror_combs):
-            for j, comb in enumerate(transpose_combinations):
-                possible_loc[i, j] = np.array(point)[np.array(comb)]
-
-        with build(pipeline):
-            seen_transposed = False
-            seen_node = True
-            for i in range(100):
-                batch = pipeline.request_batch(request)
-
-                if len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1:
-                    seen_node = True
-                    node = list(batch[GraphKeys.TEST_GRAPH].nodes)[0]
-
-                    # Check if your location is possible
-                    assert node.location in possible_loc
-                    seen_transposed = seen_transposed or any(
-                        [node.location[dim] != og_point[dim] for dim in range(3)]
-                    )
-                    assert Roi((0, 20, 33), (100, 100, 120)).contains(
-                        batch[GraphKeys.TEST_GRAPH].spec.roi
-                    )
-                    assert batch[GraphKeys.TEST_GRAPH].spec.roi.contains(node.location)
-
-                for (array_key, array) in batch.arrays.items():
-                    assert (
-                        batch.arrays[array_key].data.shape
-                        == batch.arrays[array_key].spec.roi.get_shape()
-                    )
-            assert seen_transposed
-            assert seen_node
-
-    def test_square(self):
-
-        test_graph = GraphKey("TEST_GRAPH")
-        test_array1 = ArrayKey("TEST_ARRAY1")
-        test_array2 = ArrayKey("TEST_ARRAY2")
-
-        pipeline = (
-            (ArrayTestSource(), ExampleSource())
-            + MergeProvider()
-            + Pad(test_array1, None)
-            + Pad(test_array2, None)
-            + Pad(test_graph, None)
-            + SimpleAugment(mirror_only=[1, 2], transpose_only=[1, 2])
-        )
-
-        request = BatchRequest()
-        request[GraphKeys.TEST_GRAPH] = GraphSpec(roi=Roi((0, 50, 65), (100, 100, 100)))
-        request[ArrayKeys.TEST_ARRAY1] = ArraySpec(roi=Roi((0, 0, 15), (100, 200, 200)))
-        request[ArrayKeys.TEST_ARRAY2] = ArraySpec(
-            roi=Roi((0, 50, 65), (100, 100, 100))
-        )
-
-        with build(pipeline):
-            for i in range(100):
-                batch = pipeline.request_batch(request)
-                assert len(list(batch[GraphKeys.TEST_GRAPH].nodes)) == 1
-
-                for (array_key, array) in batch.arrays.items():
-                    assert (
-                        batch.arrays[array_key].data.shape
-                        == batch.arrays[array_key].spec.roi.get_shape()
-                    )
-
-
-class CornerSource(BatchProvider):
-    """
-    for any request of shape [a, b, c] (3d for illustration. number of dimensions is
-    configurable with dims arg), returns an array of zeros of shape [a, b, c]
-    with only the index [0, 0, c] = 1.
-    """
-
-    def __init__(self, key, dims=2, voxel_size=None, dtype=None):
-        self.key = key
-        self.dims = dims
-        self.voxel_size = voxel_size
-        self.dtype = dtype
-
-    def setup(self):
-        self.provides(
-            self.key,
-            ArraySpec(
-                roi=Roi((None,) * self.dims, (None,) * self.dims),
-                voxel_size=self.voxel_size,
-                dtype=self.dtype,
-            ),
-        )
-
-    def provide(self, request):
-        outputs = Batch()
-        roi = request[self.key].roi
-
-        shape = roi.get_shape() / self.spec[self.key].voxel_size
-        dtype = self.dtype
-
-        data = np.zeros(shape, dtype=dtype)
-        corner = tuple(shape[i] - 1 if i == len(shape) else 0 for i in range(self.dims))
-        data[corner] = 1
-
-        spec = self.spec[self.key].copy()
-        spec.roi = roi
-
-        outputs[self.key] = Array(data, spec)
-
-        return outputs
+        assert (
+            batch[array_key].data[node_voxel_index] == 1
+        ), f"Node at {np.where(batch[array_key].data == 1)} not {node_voxel_index}"
 
 
 def test_mismatched_voxel_multiples():
@@ -379,7 +217,7 @@ def test_mismatched_voxel_multiples():
         dist_to_center = center - roi.get_offset() -> [2, 3]
         dist_to_center = transpose(dist_to_center)  -> [3, 2]
 
-        # Using the tranposed distance to center, get the correct offset.
+        # Using the transposed distance to center, get the offset.
         new_offset = center - dist_to_center -> [-1, 1]
 
         shape = transpose(shape) -> [6, 4]
@@ -389,28 +227,33 @@ def test_mismatched_voxel_multiples():
 
     This result is what we would expect from tranposing, but no longer fits the voxel grid.
     dist_to_center should be limited to multiples of the lcm_voxel_size.
+
+        instead we should get:
+        original = ((0, 0), (4, 6))
+        transposed = ((0, 0), (6, 4))
     """
 
     test_array = ArrayKey("TEST_ARRAY")
-
-    source = CornerSource(test_array, voxel_size=(2, 2))
+    data = np.zeros([3, 3])
+    data[
+        2, 1
+    ] = 1  # voxel has Roi((4, 2) (2, 2)). Contained in Roi((0, 0), (6, 4)). at 2, 1
+    source = ArraySource(
+        test_array,
+        Array(
+            data,
+            ArraySpec(roi=Roi((0, 0), (6, 6)), voxel_size=(2, 2)),
+        ),
+    )
     pipeline = source + SimpleAugment(
-        transpose_only=[0, 1]
+        mirror_only=[], transpose_only=[0, 1], transpose_probs=1
     )
 
     with build(pipeline):
-        loop = 100
-        while loop > 0:
-            request = BatchRequest()
-            request[test_array] = ArraySpec(roi=Roi((0, 0), (4, 6)))
-            loop -= 1
+        request = BatchRequest()
+        request[test_array] = ArraySpec(roi=Roi((0, 0), (4, 6)))
 
-            pre_request_provided_roi = source.spec[test_array].roi
-            batch = pipeline.request_batch(request)
-            assert pre_request_provided_roi == source.spec[test_array].roi
-            data = batch[test_array].data
+        batch = pipeline.request_batch(request)
+        data = batch[test_array].data
 
-            if data.sum(axis=1)[0] == 1:
-                loop = -1
-        assert loop < 0, "Data was never transposed!"
-
+        assert data[1, 2] == 1, f"{data}"


### PR DESCRIPTION
expands upon Peter's pull request here https://github.com/funkey/gunpowder/pull/149

Fixed a couple bugs in simple augment for graphs.
1) graph augments were relative to a total roi calculated via `batch.get_total_roi()`. However since the arrays had already been handled in place, this resulted in performing graph augmentations relative to the already transformed total roi.
2) transform was done relative to the total roi offset, not the center which could lead to problems for non square rois.
3) possibility of finding a center that was not a multiple of the voxel size was not accounted for. This could cause issues for voxel_sizes > 1 if 1 transposed axis was an even multiple of the voxel size, and another axis was an odd multiple of the voxel size.

overhauled the tests to properly ensure that the augmentations occur as expected and that the graph augmentations match the array augmentations.

Added support for predefining the probability of mirroring each axis or applying a permutation of the axes.


I don't like how probabilities are defined for transposing axes. I'd appreciate any ideas on how to improve on what I wrote which is sufficient for testing purposes, but not generally useful.