### PR TITLE
Add hook for data-dependent snapshots

### DIFF
--- a/gunpowder/nodes/snapshot.py
+++ b/gunpowder/nodes/snapshot.py
@@ -90,6 +90,26 @@ class Snapshot(BatchFilter):
 
         self.mode = "w"
 
+    def write_if(self, batch):
+        """To be implemented in subclasses.
+
+        This function is run in :func:`process` and enables data-dependent
+        snapshots. The snapshot will not contain the keys in
+        ``additional_request``.
+
+        Args:
+
+            batch (:class:`Batch`):
+
+                The batch received from upstream to be modified by this node.
+
+        Returns:
+
+            ``True`` if ``batch`` should be written to snapshot, ``False``
+            otherwise.
+        """
+        return False
+
     def setup(self):
 
         for key, _ in self.additional_request.items():
@@ -129,6 +149,9 @@ class Snapshot(BatchFilter):
         return deps
 
     def process(self, batch, request):
+
+        if self.write_if(batch):
+            self.record_snapshot = True
 
         if self.record_snapshot:
 


### PR DESCRIPTION
It can be useful to write out snapshots based on some condition in the current batch, especially for developing and debugging. Here is an example subclass that writes out a snapshot if there's a spike in the recorded loss. 

```
import numpy as np
from gunpowder import Snapshot

class SnapshotLossIncrease(Snapshot):
    def __init__(self, factor, **kwargs):
        super().__init__(**kwargs)
        self.factor = factor
        self.running_loss = float('inf')

    def write_if(self, batch):
        out = self.running_loss * self.factor < batch.loss
        self.running_loss = batch.loss
        return out
```