### PR TITLE
In NoiseAugment, call assert for data in [0, 1] only if clip is True

### DIFF
--- a/gunpowder/nodes/noise_augment.py
+++ b/gunpowder/nodes/noise_augment.py
@@ -50,7 +50,8 @@ class NoiseAugment(BatchFilter):
         raw = batch.arrays[self.array]
 
         assert raw.data.dtype == np.float32 or raw.data.dtype == np.float64, "Noise augmentation requires float types for the raw array (not " + str(raw.data.dtype) + "). Consider using Normalize before."
-        assert raw.data.min() >= -1 and raw.data.max() <= 1, "Noise augmentation expects raw values in [-1,1] or [0,1]. Consider using Normalize before."
+        if self.clip:
+            assert raw.data.min() >= -1 and raw.data.max() <= 1, "Noise augmentation expects raw values in [-1,1] or [0,1]. Consider using Normalize before."
         raw.data = skimage.util.random_noise(
             raw.data,
             mode=self.mode,


### PR DESCRIPTION
Just a small fix that removes an unnecessary assert in NoiseAugment.

Calling NoiseAugment for data that is not in the range of [0, 1] should be possible.
Noise augment warps skimage.util.random_noise internally, that can handle any input range.

For clip==False there should be no assert in any case. 
I have left the assert in place for when clip==True as it seems reasonable.
Note however that this creates an arbitrary restriction. Even for clip==True, skimage.util.random_noise can handle inputs outside of the range [0,1] it just clips the output after adding the noise.

Pre-Merge Checklist:

- [no] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [no] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [yes] PR branch name is short and describes the feature/bug addressed in this PR
- [yes] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [not yet] changes reviewed by another contributor
- [yes] tests cover changes
- [not tested] all tests pass
