### PR TITLE
Total Roi with nonspatial Array

### DIFF
--- a/gunpowder/batch.py
+++ b/gunpowder/batch.py
@@ -138,12 +138,18 @@ class Batch(Freezable):
 
         total_roi = None
 
-        for collection_type in [self.arrays, self.graphs]:
-            for (key, obj) in collection_type.items():
+        for _, array in self.arrays.items():
+            if not array.spec.nonspatial:
                 if total_roi is None:
-                    total_roi = obj.spec.roi
+                    total_roi = array.spec.roi
                 else:
-                    total_roi = total_roi.union(obj.spec.roi)
+                    total_roi = total_roi.union(array.spec.roi)
+
+        for _, graph in self.graphs.items():
+            if total_roi is None:
+                total_roi = graph.spec.roi
+            else:
+                total_roi = total_roi.union(graph.spec.roi)
 
         return total_roi
 

--- a/tests/cases/batch.py
+++ b/tests/cases/batch.py
@@ -1,0 +1,37 @@
+import logging
+import numpy as np
+
+from gunpowder import (
+    Array,
+    ArrayKey,
+    ArraySpec,
+    Batch,
+    Coordinate,
+    Roi,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_get_total_roi_nonspatial_array():
+
+    raw = ArrayKey('RAW')
+    nonspatial = ArrayKey('NONSPATIAL')
+
+    voxel_size = Coordinate((1, 2))
+    roi = Roi((100, 200), (20, 20))
+
+    raw_spec = ArraySpec(roi=roi, voxel_size=voxel_size)
+    nonspatial_spec = ArraySpec(nonspatial=True)
+
+    batch = Batch()
+    batch[raw] = Array(
+        data=np.zeros((20, 10)),
+        spec=raw_spec
+    )
+    batch[nonspatial] = Array(
+        data=np.zeros((2, 3)),
+        spec=nonspatial_spec
+    )
+
+    assert batch.get_total_roi() == roi


### PR DESCRIPTION
The calculation of the total `Roi` of a `Batch`  should exclude the `Roi`s of nonspatial `Array`s.

Pre-Merge Checklist:

- [yes] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [yes] PR branch name is short and describes the feature/bug addressed in this PR
- [yes] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [not yet] changes reviewed by another contributor
- [yes] tests cover changes
- [yes] all tests pass
