### PR TITLE
Extend docs for Reject

### DIFF
--- a/gunpowder/nodes/reject.py
+++ b/gunpowder/nodes/reject.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 class Reject(BatchFilter):
     '''Reject batches based on the masked-in vs. masked-out ratio.
 
+    If a pipeline also contains a :class:`RandomLocation` node,
+    :class:`Reject` needs to be placed downstream of it.
+
     Args:
 
         mask (:class:`ArrayKey`, optional):


### PR DESCRIPTION
Placing `Reject` downstream of `RandomLocation` is crucial, as the inverse leads to requesting the same location repeatedly, which might go unnoticed if `reject_probability<1`.

Pre-Merge Checklist:

- [yes] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [yes] PR branch name is short and describes the feature/bug addressed in this PR
- [yes] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [not yet] changes reviewed by another contributor
- [not applicable] tests cover changes
- [not applicable] all tests pass
