### PR TITLE
Add support for providing random shift and random provider to batch

### DIFF
--- a/gunpowder/nodes/random_provider.py
+++ b/gunpowder/nodes/random_provider.py
@@ -8,7 +8,7 @@ from .batch_provider import BatchProvider
 
 
 class RandomProvider(BatchProvider):
-    '''Randomly selects one of the upstream providers::
+    """Randomly selects one of the upstream providers::
 
         (a + b + c) + RandomProvider()
 
@@ -17,15 +17,22 @@ class RandomProvider(BatchProvider):
     the same.
 
     Args:
-        probabilities (1-D array-like, optional): An optional list of
+        probabilities (1-D array-like, optional):
+
+            An optional list of
             probabilities for choosing upstream providers, given in the
             same order. Probabilities do not need to be normalized. Default
             is ``None``, corresponding to equal probabilities.
-    '''
 
-    def __init__(self, probabilities=None, randomness_store_key=None):
+        random_provider_key (``ArrayKey``):
+
+            If provided, this node will store the index of the chosen random
+            provider in a nonspatial array.
+    """
+
+    def __init__(self, probabilities=None, random_provider_key=None):
         self.probabilities = probabilities
-        self.randomness_store_key = randomness_store_key
+        self.random_provider_key = random_provider_key
 
         # automatically normalize probabilities to sum to 1
         if self.probabilities is not None:
@@ -42,7 +49,7 @@ class RandomProvider(BatchProvider):
             assert len(self.get_upstream_providers()) == len(self.probabilities), (
                 "if probabilities are specified, they "
                 "need to be given for each batch "
-                                     "provider added to the RandomProvider"
+                "provider added to the RandomProvider"
             )
 
         common_spec = None
@@ -60,24 +67,24 @@ class RandomProvider(BatchProvider):
         for key, spec in common_spec.items():
             self.provides(key, spec)
 
-        if self.randomness_store_key is not None:
-            self.provides(self.randomness_store_key, ArraySpec(nonspatial=True))
+        if self.random_provider_key is not None:
+            self.provides(self.random_provider_key, ArraySpec(nonspatial=True))
 
     def provide(self, request):
         # Random seed is set in provide rather than prepare since this node
         # is not a batch filter
         np.random.seed(request.random_seed)
 
-        if self.randomness_store_key is not None:
-            del request[self.randomness_store_key]
+        if self.random_provider_key is not None:
+            del request[self.random_provider_key]
 
         i = np.random.choice(
             range(len(self.get_upstream_providers())), p=self.probabilities
         )
         provider = self.get_upstream_providers()[i]
         batch = provider.request_batch(request)
-        if self.randomness_store_key is not None:
-            batch[self.randomness_store_key] = Array(
+        if self.random_provider_key is not None:
+            batch[self.random_provider_key] = Array(
                 np.array(i), ArraySpec(nonspatial=True)
             )
         return batch

--- a/gunpowder/nodes/random_provider.py
+++ b/gunpowder/nodes/random_provider.py
@@ -29,18 +29,21 @@ class RandomProvider(BatchProvider):
 
         # automatically normalize probabilities to sum to 1
         if self.probabilities is not None:
-            self.probabilities = [float(x)/np.sum(probabilities) for x in
-                                  self.probabilities]
+            self.probabilities = [
+                float(x) / np.sum(probabilities) for x in self.probabilities
+            ]
 
     def setup(self):
         self.enable_placeholders()
-        assert len(self.get_upstream_providers()) > 0,\
-            "at least one batch provider must be added to the RandomProvider"
+        assert (
+            len(self.get_upstream_providers()) > 0
+        ), "at least one batch provider must be added to the RandomProvider"
         if self.probabilities is not None:
-            assert len(self.get_upstream_providers()) == len(
-                self.probabilities), "if probabilities are specified, they " \
-                                     "need to be given for each batch " \
+            assert len(self.get_upstream_providers()) == len(self.probabilities), (
+                "if probabilities are specified, they "
+                "need to be given for each batch "
                                      "provider added to the RandomProvider"
+            )
 
         common_spec = None
 

--- a/tests/cases/random_provider.py
+++ b/tests/cases/random_provider.py
@@ -1,0 +1,61 @@
+from gunpowder import (
+    RandomProvider,
+    Roi,
+    ArrayKey,
+    ArraySpec,
+    Array,
+    Roi,
+    BatchRequest,
+    build,
+)
+import numpy as np
+
+from .helper_sources import ArraySource
+
+
+def test_output():
+    a = ArrayKey("A")
+    source_a = ArraySource(
+        a,
+        Array(
+            np.zeros((5, 15, 25), dtype=np.uint8),
+            spec=ArraySpec(
+                roi=Roi((0, 0, 0), (50, 60, 50)), voxel_size=(10, 4, 2), dtype=np.uint8
+            ),
+        ),
+    )
+    source_b = ArraySource(
+        a,
+        Array(
+            np.ones((5, 15, 25), dtype=np.uint8),
+            spec=ArraySpec(
+                roi=Roi((0, 0, 0), (50, 60, 50)), voxel_size=(10, 4, 2), dtype=np.uint8
+            ),
+        ),
+    )
+    random_provider = ArrayKey("RANDOM_PROVIDER")
+
+    pipeline = (source_a, source_b) + RandomProvider(randomness_store_key=random_provider)
+
+    with build(pipeline):
+
+        possibilities = set([0, 1])
+        seen = set()
+        for i in range(10):
+            batch = pipeline.request_batch(
+                BatchRequest(
+                    {
+                        a: ArraySpec(roi=Roi((0, 0, 0), (20, 20, 20))),
+                        random_provider: ArraySpec(nonspatial=True)
+                    }
+                )
+            )
+
+            value = batch.arrays[a].data[0, 0, 0]
+            assert value in possibilities
+            assert batch.arrays[random_provider].data.item() == value
+            seen.add(value)
+            if len(possibilities - seen) == 0:
+                break
+
+        assert seen == possibilities


### PR DESCRIPTION
Pre-Merge Checklist:

- [x] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [x] PR branch name is short and describes the feature/bug addressed in this PR
- [x] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [x] tests cover changes
- [x] all tests pass

You can now provide the `RandomLocation` node an array key which it will populate with the random shift chosen for each batch.
You can now provide the `RandomProvider` node an array key which it will populate with the index of the random provider chosen for each batch.

TODO:
same thing for other random nodes such as elastic augment, shift augment etc.