### PR TITLE
AddAffinities prepare bug

### DIFF
--- a/gunpowder/nodes/add_affinities.py
+++ b/gunpowder/nodes/add_affinities.py
@@ -159,24 +159,6 @@ class AddAffinities(BatchFilter):
 
     def prepare(self, request):
 
-        if self.labels_mask:
-            assert (
-                request[self.labels].roi ==
-                request[self.labels_mask].roi),(
-                "requested GT label roi %s and GT label mask roi %s are not "
-                "the same."%(
-                    request[self.labels].roi,
-                    request[self.labels_mask].roi))
-
-        if self.unlabelled:
-            assert (
-                request[self.labels].roi ==
-                request[self.unlabelled].roi),(
-                "requested GT label roi %s and GT unlabelled mask roi %s are not "
-                "the same."%(
-                    request[self.labels].roi,
-                    request[self.unlabelled].roi))
-
         deps = BatchRequest()
 
         # grow labels ROI to accomodate padding


### PR DESCRIPTION
`prepare` method asserts expected `labels` key to be in request despite not
providing or updating `labels`.
This does not align with the gunpowder dependency flow where each node
should simply request exactly what it needs to provide or update the arrays
that are requested of it.

Pre-Merge Checklist:

- [ ] if this PR adds a feature: request merge into the latest development branch (`vX.Y-dev`)
- [x] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [x] PR branch name is short and describes the feature/bug addressed in this PR
- [x] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [x] tests cover changes
- [x] all tests pass
