### PR TITLE
Move batch provider.  add  

### DIFF
--- a/gunpowder/nodes/batch_provider.py
+++ b/gunpowder/nodes/batch_provider.py
@@ -355,3 +355,31 @@ class BatchProvider(object):
     def __repr__(self):
 
         return self.name() + ", providing: " + str(self.spec)
+
+    def __add__(self, other):
+        '''Support ``self + other`` operator. Return a :class:`Pipeline`.'''
+        from gunpowder import Pipeline
+
+        if isinstance(other, BatchProvider):
+            other = Pipeline(other)
+
+        if not isinstance(other, Pipeline):
+            raise RuntimeError(
+                f"Don't know how to add {type(other)} to BatchProvider "
+                f"{self.name()}")
+
+        return Pipeline(self) + other
+
+    def __radd__(self, other):
+        '''Support ``other + self`` operator. Return a :class:`Pipeline`.'''
+        from gunpowder import Pipeline
+
+        if isinstance(other, BatchProvider):
+            return Pipeline(other) + Pipeline(self)
+
+        if isinstance(other, tuple):
+            return other + Pipeline(self)
+
+        raise RuntimeError(
+            f"Don't know how to radd {type(other)} to BatchProvider"
+            f"{self.name()}")

--- a/gunpowder/pipeline.py
+++ b/gunpowder/pipeline.py
@@ -223,36 +223,3 @@ class Pipeline:
             res += " -> "
         res += reprs[-1]
         return res
-
-
-# monkey-patch BatchProvider, such that + operator returns Pipeline
-
-
-def batch_provider_add(self, other):
-
-    if isinstance(other, BatchProvider):
-        other = Pipeline(other)
-
-    if not isinstance(other, Pipeline):
-        raise RuntimeError(
-            f"Don't know how to add {type(other)} to BatchProvider "
-            f"{self.name()}")
-
-    return Pipeline(self) + other
-
-
-def batch_provider_radd(self, other):
-
-    if isinstance(other, BatchProvider):
-        return Pipeline(other) + Pipeline(self)
-
-    if isinstance(other, tuple):
-        return other + Pipeline(self)
-
-    raise RuntimeError(
-        f"Don't know how to radd {type(other)} to BatchProvider"
-        f"{self.name()}")
-
-
-BatchProvider.__add__ = batch_provider_add
-BatchProvider.__radd__ = batch_provider_radd

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ version = version_info['_version']
 setup(
         name=name,
         version=str(version),
-        description='Data loading DAG for Greentea.',
+        description='A library to facilitate machine learning on large, multi-dimensional images.',
         url='https://github.com/funkey/gunpowder',
         author='Jan Funke',
         author_email='jfunke@iri.upc.edu',


### PR DESCRIPTION
This PR puts the `__add__` and `__radd__` methods directly on `BatchProvider`, rather than dynamically monkeypatching it when `pipeline.py` is imported.  This makes it easier to inspect, and appeases type checkers that yell at you when you try to add a tuple of `Source` objects to a `BatchProvider`:

<img width="509" alt="Screen Shot 2022-09-07 at 7 23 36 PM" src="https://user-images.githubusercontent.com/1609449/189000981-e74485a7-1ea0-43a1-af4a-05c795c87ca6.png">


Pre-Merge Checklist:

- [x] if this PR fixes a bug: request merge into the latest patch branch (`patch-X.Y.Z`)
- [x] PR branch name is short and describes the feature/bug addressed in this PR
- [x] commit messages [are consistent](https://chris.beams.io/posts/git-commit/)
- [ ] changes reviewed by another contributor
- [ ] tests cover changes
- [ ] all tests pass


note: i branched off of `master` ... which seems to be the cause for the change in setup.py (when merging into patch-1.2.3) ... let me know if I should be merging to something else.

also, couldn't run all tests locally on mac due to the subprocess issue that I think @pattonw was fixing at dl@mbl 